### PR TITLE
changed required version in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ federation.
 
 ### Building
 
-Building Semagrow from sources requires to have a system with JDK8 and maven 3. 
+Building Semagrow from sources requires to have a system with JDK8 and Maven 3.1 or higher.  
 Optionally, you may need a PostgreSQL as a requirement for the query transformation 
 functionality.
 


### PR DESCRIPTION
With Maven version 3.0.5 build fails with message:

`[ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.0:install-node-and-npm (install node and npm) on project semagrow-webgui: The plugin com.github.eirslett:frontend-maven-plugin:1.0 requires Maven version 3.1.0`