### PR TITLE
Reimplement of subquery publisher

### DIFF
--- a/rdf4j/src/main/java/org/semagrow/query/impl/SemagrowSailTupleQuery.java
+++ b/rdf4j/src/main/java/org/semagrow/query/impl/SemagrowSailTupleQuery.java
@@ -192,7 +192,7 @@ public class SemagrowSailTupleQuery extends SemagrowSailQuery implements Semagro
                     logger.error("Tuple handle solution error", e);
                 }
             }
-            subscription.cancel();
+            //subscription.cancel();
             latch.countDown();
         }
 
@@ -217,7 +217,7 @@ public class SemagrowSailTupleQuery extends SemagrowSailQuery implements Semagro
                     logger.error("Tuple handle solution error", e);
                 }
             }
-            subscription.cancel();
+            //subscription.cancel();
             latch.countDown();
         }
     }

--- a/sparql/src/main/java/org/semagrow/connector/sparql/execution/TupleQueryResultPublisher.java
+++ b/sparql/src/main/java/org/semagrow/connector/sparql/execution/TupleQueryResultPublisher.java
@@ -108,7 +108,10 @@ public class TupleQueryResultPublisher implements Publisher<BindingSet> {
                 subscriber.onError(e);
 
             } catch (InterruptedException i) {
-
+                if (shutdownFlag)
+                    logger.info("Subscription shutdown by subscriber. Interrupted.");
+                else
+                    logger.warn("SubQuery thread interrupted.");
             } finally {
                 if (result != null)
                     result.close();

--- a/sparql/src/main/java/org/semagrow/connector/sparql/execution/TupleQueryResultPublisher.java
+++ b/sparql/src/main/java/org/semagrow/connector/sparql/execution/TupleQueryResultPublisher.java
@@ -173,7 +173,8 @@ public class TupleQueryResultPublisher implements Publisher<BindingSet> {
             if (producer != null) {
                 producer.shutdown();
                 assert f != null;
-                f.cancel(true);
+                if (!f.isDone() && !f.isCancelled())
+                    f.cancel(true);
             }
         }
     }


### PR DESCRIPTION
The implementation of the TupleQueryResultPublisher did not respect the request argument of the potential consumer according to the specifications of [Reactive Streams](https://github.com/reactive-streams/reactive-streams-jvm). 

Its behavior is to publish all the results of the sub query despite the fact that the consumer requested only some. This confuses the stream implementation of reactor and as a result the total results may differ in subsequent runs. The number of results was non-deterministic and probably depend on the rate of processing the bindingsets of the query answer.

This reimplementation uses the rdf4j [TupleQueryResult](https://github.com/eclipse/rdf4j/blob/master/core/query/src/main/java/org/eclipse/rdf4j/query/TupleQueryResult.java) that holds the results into a blocking queue. The publisher pops only the elements requested by the consumer.

Caveats:
If the consumer will request elements in a very slow rate the queue might need to contain the majority of the sub query results defying the purpose of backpressure. A different implementation might consider implementing the http response using netty that probably implements backpressure in a more primitive way (possibly by not consuming the input of the socket and thus relying on the nature of TCP/IP in case some blocks are dropped). For future reference cf [github/netty-reactive-streams].

[github/netty-reactive-streams]: https://github.com/playframework/netty-reactive-streams



