### PR TITLE
Fix LeftJoin handling in cost estimation and planning

### DIFF
--- a/core/src/main/java/org/semagrow/plan/operators/BindLeftJoin.java
+++ b/core/src/main/java/org/semagrow/plan/operators/BindLeftJoin.java
@@ -1,0 +1,34 @@
+package org.semagrow.plan.operators;
+
+import org.eclipse.rdf4j.query.algebra.LeftJoin;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.ValueExpr;
+
+/**
+ * Created by angel on 5/5/2017.
+ */
+public class BindLeftJoin  extends LeftJoin {
+
+    public BindLeftJoin(TupleExpr e1, TupleExpr e2) {
+        super(e1,e2);
+    }
+
+    public BindLeftJoin(TupleExpr leftArg, TupleExpr rightArg, ValueExpr condition) {
+        this(leftArg, rightArg);
+        this.setCondition(condition);
+    }
+
+    @Override
+    public int hashCode() {
+        return "bind-left".hashCode() + super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof BindLeftJoin) {
+            BindLeftJoin j = (BindLeftJoin) o;
+            return getLeftArg().equals(j.getLeftArg()) && getRightArg().equals(j.getRightArg());
+        }
+        return false;
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/queryblock/SelectBlock.java
+++ b/core/src/main/java/org/semagrow/plan/queryblock/SelectBlock.java
@@ -4,10 +4,7 @@ import org.eclipse.rdf4j.query.algebra.*;
 import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
 import org.semagrow.local.LocalSite;
 import org.semagrow.plan.*;
-import org.semagrow.plan.operators.BindJoin;
-import org.semagrow.plan.operators.CrossProduct;
-import org.semagrow.plan.operators.HashJoin;
-import org.semagrow.plan.operators.SourceQuery;
+import org.semagrow.plan.operators.*;
 import org.semagrow.selector.Site;
 import org.semagrow.util.CombinationIterator;
 import org.semagrow.util.PartitionedSet;
@@ -823,6 +820,7 @@ public class SelectBlock extends AbstractQueryBlock {
                                 plans.add(context.asPlan(b));
                                 // apply thetajoin predicates in pp2 and then bindjoin (pp1, filter(pp2))
                             }
+
                         }
                     }
                 }
@@ -967,7 +965,7 @@ public class SelectBlock extends AbstractQueryBlock {
 
                 for (Plan pp1 : pp1c) {
                     for (Plan pp2 : pp2c) {
-                        LeftJoin b = new LeftJoin(pp1, pp2);
+                        LeftJoin b = new BindLeftJoin(pp1, pp2);
                         // find remaining thetajoin predicates and also apply then in b
                         plans.add(context.asPlan(b));
 

--- a/core/src/main/java/org/semagrow/plan/queryblock/SelectMergeVisitor.java
+++ b/core/src/main/java/org/semagrow/plan/queryblock/SelectMergeVisitor.java
@@ -57,15 +57,15 @@ public class SelectMergeVisitor extends AbstractQueryBlockVisitor<RuntimeExcepti
 
             SelectBlock lower = (SelectBlock) q.getBlock();
 
-            // move quantifiers in q.getBlock() to parent
-            for (Quantifier qq : new HashSet<>(lower.getQuantifiers()))
-                upper.moveQuantifier(qq);
-
             // move predicates in q.getBlock() to parent
             for (Predicate p : new HashSet<>(lower.getPredicates()))
                 upper.movePredicate(p);
 
             upper.visit(new PredicateProcessor(q));
+
+            // move quantifiers in q.getBlock() to parent
+            for (Quantifier qq : new HashSet<>(lower.getQuantifiers()))
+                upper.moveQuantifier(qq);
 
             // process outputVariables and duplicate strategy
             processHead(upper, q);

--- a/core/src/main/java/org/semagrow/plan/queryblock/SelectMergeVisitor.java
+++ b/core/src/main/java/org/semagrow/plan/queryblock/SelectMergeVisitor.java
@@ -192,15 +192,17 @@ public class SelectMergeVisitor extends AbstractQueryBlockVisitor<RuntimeExcepti
                     if (entry.getValue() instanceof Quantifier.Var) {
                         boolean inNullProducingSide = jp.getTo().getQuantifier().equals(entry.getKey().getQuantifier());
 
+                        Quantifier qTo = jp.getTo().getQuantifier();
+                        SelectBlock qb = (SelectBlock) qTo.getBlock();
+                        Collection<Quantifier> qs = qb.getQuantifiers();
+
                         jp.replaceVarWith(entry.getKey(), (Quantifier.Var) entry.getValue());
-                        jp.getEEL().remove(q);
 
                         if (inNullProducingSide) {
-                            Quantifier q = jp.getTo().getQuantifier();
-                            SelectBlock qb = (SelectBlock) q.getBlock();
-                            Collection<Quantifier> qs = qb.getQuantifiers();
+                            jp.getEEL().remove(q);
                             jp.getEEL().addAll(qs);
                         } else {
+                            jp.getEEL().remove(q);
                             jp.getEEL().add(((Quantifier.Var) entry.getValue()).getQuantifier());
                         }
 

--- a/core/src/main/java/org/semagrow/plan/queryblock/SelectMergeVisitor.java
+++ b/core/src/main/java/org/semagrow/plan/queryblock/SelectMergeVisitor.java
@@ -193,14 +193,13 @@ public class SelectMergeVisitor extends AbstractQueryBlockVisitor<RuntimeExcepti
                         boolean inNullProducingSide = jp.getTo().getQuantifier().equals(entry.getKey().getQuantifier());
 
                         Quantifier qTo = jp.getTo().getQuantifier();
-                        SelectBlock qb = (SelectBlock) qTo.getBlock();
-                        Collection<Quantifier> qs = qb.getQuantifiers();
 
                         jp.replaceVarWith(entry.getKey(), (Quantifier.Var) entry.getValue());
 
                         if (inNullProducingSide) {
+                            SelectBlock qb = (SelectBlock) qTo.getBlock();
                             jp.getEEL().remove(q);
-                            jp.getEEL().addAll(qs);
+                            jp.getEEL().addAll(qb.getQuantifiers());
                         } else {
                             jp.getEEL().remove(q);
                             jp.getEEL().add(((Quantifier.Var) entry.getValue()).getQuantifier());

--- a/http-endpoint/src/main/java/org/semagrow/http/views/TupleQueryResultView.java
+++ b/http-endpoint/src/main/java/org/semagrow/http/views/TupleQueryResultView.java
@@ -76,6 +76,9 @@ public class TupleQueryResultView extends QueryResultView {
             } catch (TupleQueryResultHandlerException var18) {
                 this.logger.error("Serialization error", var18);
                 response.sendError(500, "Serialization error: " + var18.getMessage());
+            } catch (Exception e) {
+                this.logger.error("Unknown internal error", e);
+                response.sendError(500, "Internal error: " + e.getMessage());
             } finally {
                 out.close();
             }


### PR DESCRIPTION
Left-Join cost was not implemented correctly. 
A new BindLeftJoin has been introduced to distinguish logical LeftJoin from the physical operator and support a specific cost estimation.

Various other bugfixes during debugging the query planning.
