### PR TITLE
Logs subquery error pushed to onError

### DIFF
--- a/sparql/src/main/java/org/semagrow/connector/sparql/execution/TupleQueryResultPublisher.java
+++ b/sparql/src/main/java/org/semagrow/connector/sparql/execution/TupleQueryResultPublisher.java
@@ -105,6 +105,7 @@ public class TupleQueryResultPublisher implements Publisher<BindingSet> {
                 }
 
             } catch (QueryEvaluationException e) {
+                logger.warn("Error while evaluating subquery", e);
                 subscriber.onError(e);
 
             } catch (InterruptedException i) {


### PR DESCRIPTION
QueryEvaluationException should be logged as warnings.