### PR TITLE
Integrate Apache Calcite as optimizer of semagrow

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -73,7 +73,33 @@
             <artifactId>postgresql</artifactId>
             <version>9.2-1004-jdbc4</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.calcite</groupId>
+            <artifactId>calcite-core</artifactId>
+            <version>1.14.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-queryrender</artifactId>
+            <version>${rdf4j.version}</version>
+        </dependency>
 
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-queryparser-api</artifactId>
+            <version>${rdf4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-queryparser-sparql</artifactId>
+            <version>${rdf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>2.4.7</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/core/src/main/java/org/semagrow/plan/rel/CatalogReader.java
+++ b/core/src/main/java/org/semagrow/plan/rel/CatalogReader.java
@@ -1,0 +1,25 @@
+package org.semagrow.plan.rel;
+
+
+import org.semagrow.plan.rel.schema.DatasetDescriptor;
+import org.semagrow.plan.rel.schema.RelOptDataset;
+import org.semagrow.plan.rel.sparql.SparqlDatasetDescriptor;
+import org.semagrow.plan.rel.sparql.SparqlDialect;
+
+/**
+ * A catalog reader contains the metadata needed for the datasets Semagrow federates.
+ */
+public interface CatalogReader {
+
+    static CatalogReader INSTANCE = new Impl();
+
+    RelOptDataset getDataset();
+
+    class Impl implements CatalogReader {
+
+        private DatasetDescriptor descriptor = new SparqlDatasetDescriptor(SparqlDialect.create(), "local");
+
+        public RelOptDataset getDataset() { return descriptor.getSegment(null, null, null, null); }
+
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/PlainNlsString.java
+++ b/core/src/main/java/org/semagrow/plan/rel/PlainNlsString.java
@@ -1,0 +1,49 @@
+package org.semagrow.plan.rel;
+
+import org.apache.calcite.sql.SqlCollation;
+import org.apache.calcite.util.NlsString;
+
+import java.util.Objects;
+
+/**
+ * Created by angel on 7/7/2017.
+ */
+public class PlainNlsString extends NlsString {
+
+    private String language;
+
+    /**
+     * Creates a string in a specfied character set.
+     *
+     * @param value       String constant, must not be null
+     * @param charsetName Name of the character set, may be null
+     * @param collation   Collation, may be null
+     * @throws IllegalCharsetNameException If the given charset name is illegal
+     * @throws UnsupportedCharsetException If no support for the named charset
+     *                                     is available in this instance of the Java virtual machine
+     * @throws RuntimeException            If the given value cannot be represented in the
+     *                                     given charset
+     */
+    public PlainNlsString(String value, String charsetName, SqlCollation collation) {
+        super(value, charsetName, collation);
+    }
+
+    public PlainNlsString(String value, String charsetName, SqlCollation collation, String language) {
+        super(value, charsetName, collation);
+        this.language = language;
+    }
+
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    @Override public boolean equals(Object o) {
+        if (!(o instanceof PlainNlsString)) {
+            return false;
+        }
+        PlainNlsString that = (PlainNlsString) o;
+        return super.equals(o) && Objects.equals(language, that.language);
+    }
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/RdfRexBuilder.java
+++ b/core/src/main/java/org/semagrow/plan/rel/RdfRexBuilder.java
@@ -1,0 +1,106 @@
+package org.semagrow.plan.rel;
+
+
+import org.apache.calcite.avatica.util.ByteString;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlCollation;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.NlsString;
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.semagrow.plan.rel.type.RDFTypes;
+import org.semagrow.plan.rel.type.RdfDataTypeFactory;
+import org.semagrow.plan.rel.type.RdfDataTypeFactoryImpl;
+
+import java.math.BigDecimal;
+
+
+/**
+ * Created by angel on 6/7/2017.
+ */
+public class RdfRexBuilder extends RexBuilder {
+
+    private RdfDataTypeFactory rdfTypeFactory;
+    /**
+     * Creates a RexBuilder.
+     *
+     * @param typeFactory Type factory
+     */
+    public RdfRexBuilder(RdfDataTypeFactory typeFactory) {
+
+        super(typeFactory);
+        rdfTypeFactory = typeFactory;
+    }
+
+    public RexNode makeRDFLiteral(Literal l) {
+        //new PlainNlsString()
+        RelDataType type = getRelDataType(l);
+        SqlTypeName sqlTypeName = type.getSqlTypeName();
+        Comparable lit = unwrapLit(l);
+
+        return makeLiteral(unwrapLit(l), type, sqlTypeName);
+    }
+
+    public RexNode makeRDFResource(Resource r) {
+        RelDataType type = getRelDataType(r);
+        SqlTypeName sqlTypeName = type.getSqlTypeName();
+
+        return makeLiteral(new NlsString(r.stringValue(), null, null), type, sqlTypeName);
+    }
+
+    public RelDataType getRelDataType(Literal l) {
+        if (l.getDatatype() == null)
+            return RDFTypes.PLAIN_LITERAL;
+        else {
+            // recycle if already have been create the same type.
+            return rdfTypeFactory.createRdfDataType(l.getDatatype());
+        }
+    }
+
+    public RelDataType getRelDataType(Resource r) {
+        if (r instanceof IRI)
+            return RDFTypes.IRI_TYPE;
+        else if (r instanceof BNode)
+            return RDFTypes.BLANK_NODE;
+        else
+            return null;
+    }
+
+
+    public Comparable unwrapLit(Literal l) {
+
+        IRI dt = l.getDatatype();
+
+        if (dt == null) {
+            PlainNlsString s = new PlainNlsString(l.stringValue(), null, null);
+            l.getLanguage().ifPresent(lang -> s.setLanguage(lang));
+            return s;
+        } else {
+
+            /** <tt>http://www.w3.org/2001/XMLSchema#integer</tt> */
+            if (dt.equals(XMLSchema.INTEGER))
+                return new BigDecimal(l.integerValue());
+            else if (dt.equals(XMLSchema.INT))
+                return BigDecimal.valueOf(l.intValue());
+            else if (dt.equals(XMLSchema.DECIMAL) || dt.equals(XMLSchema.DOUBLE))
+                return l.decimalValue();
+            else if (dt.equals(XMLSchema.DATE) || dt.equals(XMLSchema.DATETIME))
+                //return l.calendarValue().;
+                return null;
+            else if (dt.equals(XMLSchema.BOOLEAN))
+                return l.booleanValue();
+            else if (dt.equals(XMLSchema.BASE64BINARY))
+                return ByteString.ofBase64(l.stringValue());
+            else if (dt.equals(XMLSchema.STRING))
+                return new NlsString(l.stringValue(),  "ISO-8859-1", SqlCollation.COERCIBLE);
+            else
+                return null;
+        }
+    }
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/RelToTupleExprConverter.java
+++ b/core/src/main/java/org/semagrow/plan/rel/RelToTupleExprConverter.java
@@ -1,0 +1,389 @@
+package org.semagrow.plan.rel;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.rel.core.*;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.Union;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.ReflectUtil;
+import org.apache.calcite.util.ReflectiveVisitor;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.algebra.*;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryBindingSet;
+import org.semagrow.plan.rel.sparql.SparqlStdOperatorTable;
+
+import java.math.BigDecimal;
+import java.util.*;
+
+/**
+ * Created by antonis on 10/7/2017.
+ */
+public class RelToTupleExprConverter implements ReflectiveVisitor {
+
+    private final ReflectUtil.MethodDispatcher<TupleExpr> dispatcher;
+
+    public RelToTupleExprConverter() {
+        dispatcher = ReflectUtil.createMethodDispatcher(TupleExpr.class, this, "visit",
+                RelNode.class);
+    }
+
+    /** Dispatches a call to the {@code visit(Xxx e)} method where {@code Xxx}
+     * most closely matches the runtime type of the argument. */
+    protected TupleExpr dispatch(RelNode e) {
+        return dispatcher.invoke(e);
+    }
+
+    public TupleExpr visitChild(int i, RelNode e) {
+        return dispatch(e);
+    }
+
+    public TupleExpr convertQuery(RelRoot query) {
+        TupleExpr e = dispatch(query.rel);
+        return new org.eclipse.rdf4j.query.algebra.QueryRoot(e);
+    }
+
+    public TupleExpr visit(RelNode e) {
+        throw new AssertionError("Need to implement " + e.getClass().getName());
+    }
+
+    public TupleExpr visit(Aggregate node) {
+
+
+        TupleExpr input = visitChild(0, node.getInput());
+
+        if (node.getAggCallList().isEmpty() &&
+            node.getRowType().equals(node.getInput().getRowType()))
+        {
+            return new org.eclipse.rdf4j.query.algebra.Distinct(input);
+        }
+
+
+        org.eclipse.rdf4j.query.algebra.Group g = new org.eclipse.rdf4j.query.algebra.Group(input);
+        RelDataType t  = node.getInput().getRowType();
+        ImmutableBitSet groupSet = node.getGroupSet();
+        for (RelDataTypeField f : t.getFieldList()) {
+            if (groupSet.get(f.getIndex())) {
+                g.addGroupBindingName(f.getName());
+            }
+        }
+
+        org.eclipse.rdf4j.query.algebra.Extension e = new org.eclipse.rdf4j.query.algebra.Extension(g);
+        for (AggregateCall call: node.getAggCallList()) {
+            org.eclipse.rdf4j.query.algebra.AbstractAggregateOperator aggregate = convertAggregateCall(call, node.getRowType());
+            g.addGroupElement(new org.eclipse.rdf4j.query.algebra.GroupElem(call.getName(), aggregate));
+            e.addElement(new org.eclipse.rdf4j.query.algebra.ExtensionElem(aggregate, call.getName()));
+        }
+        return e;
+    }
+
+    private org.eclipse.rdf4j.query.algebra.AbstractAggregateOperator convertAggregateCall(AggregateCall call, RelDataType rowtype) {
+        ValueExpr arg = null;
+        if (!(call.getArgList().isEmpty())) {
+            int index = call.getArgList().get(0);
+            String varname = rowtype.getFieldList().get(index).getName();
+            arg = new Var(varname);
+        }
+        if (call.getAggregation().equals(SqlStdOperatorTable.AVG)) {
+            return new org.eclipse.rdf4j.query.algebra.Avg(arg, call.isDistinct());
+        }
+        if (call.getAggregation().equals(SqlStdOperatorTable.COUNT)) {
+            return new org.eclipse.rdf4j.query.algebra.Count(arg, call.isDistinct());
+        }
+        if (call.getAggregation().equals(SqlStdOperatorTable.MAX)) {
+            return new org.eclipse.rdf4j.query.algebra.Max(arg, call.isDistinct());
+        }
+        if (call.getAggregation().equals(SqlStdOperatorTable.MIN)) {
+            return new org.eclipse.rdf4j.query.algebra.Min(arg, call.isDistinct());
+        }
+        if (call.getAggregation().equals(SqlStdOperatorTable.SUM)) {
+            return new org.eclipse.rdf4j.query.algebra.Sum(arg, call.isDistinct());
+        }
+        if (call.getAggregation().equals(SparqlStdOperatorTable.GROUPCONCAT)) {
+            return new org.eclipse.rdf4j.query.algebra.GroupConcat(arg, call.isDistinct());
+        }
+        if (call.getAggregation().equals(SparqlStdOperatorTable.SAMPLE)) {
+            return new org.eclipse.rdf4j.query.algebra.Sample(arg, call.isDistinct());
+        }
+        return null;
+    }
+
+    public TupleExpr visit(Filter node) {
+        //ValueExpr condition = rexToValueExprConverter.convertRexNode(node.getCondition(), node.getRowType());
+        //return new Filter(convertRelNode(node.getInput()), condition);
+        return visitChild(0, node.getInput());
+    }
+
+    public TupleExpr visit(Join node) {
+
+        List<Integer> leftKeys = Lists.newArrayList();
+        List<Integer> rightKeys = Lists.newArrayList();
+
+        RexNode rest = RelOptUtil.splitJoinCondition(
+                node.getLeft(),
+                node.getRight(),
+                node.getCondition(),
+                leftKeys,
+                rightKeys,
+                null);
+
+        TupleExpr leftArg = visitChild(0, node.getLeft());
+        TupleExpr rightArg = visitChild(1, node.getRight());
+
+        TupleExpr out = null;
+
+        RexToValueExprConverter.Context ctx = new NodeContext(node);
+
+        if (node.getJoinType() == JoinRelType.INNER) {
+             out = new org.eclipse.rdf4j.query.algebra.Join(leftArg, rightArg);
+             if (!rest.isAlwaysTrue()) {
+                 ValueExpr cond = RexToValueExprConverter.convertExpression(rest, ctx);
+                 out = new org.eclipse.rdf4j.query.algebra.Filter(out, cond);
+             }
+        } else if (node.getJoinType() == JoinRelType.LEFT) {
+            if (rest.isAlwaysTrue())
+                out = new org.eclipse.rdf4j.query.algebra.LeftJoin(leftArg, rightArg);
+            else {
+                ValueExpr cond = RexToValueExprConverter.convertExpression(rest, ctx);
+                out = new org.eclipse.rdf4j.query.algebra.LeftJoin(leftArg, rightArg, cond);
+            }
+        } else {
+            throw new AssertionError();
+        }
+        return out;
+    }
+
+    public TupleExpr visit(Project node) {
+
+        TupleExpr input = visitChild(0, node.getInput());
+
+        org.eclipse.rdf4j.query.algebra.ProjectionElemList lst = new org.eclipse.rdf4j.query.algebra.ProjectionElemList();
+
+        /* create a mapping (id -> varable name) for the inner variable list */
+
+        Map<Integer, String> innerVariablesMap = new HashMap<>();
+        List innerFieldList = node.getInput().getRowType().getFieldList();
+        for (int i = 0 ; i<innerFieldList.size() ; i++) {
+            Object field = innerFieldList.get(i);
+            if (field instanceof RelDataTypeField) {
+                innerVariablesMap.put(i, ((RelDataTypeField) field).getName());
+            }
+        }
+
+        Map<String, String> renamings = new HashMap<>();
+        List<String> nullFieldList = new ArrayList();
+        List<ExtensionElem> extensionElemList = new ArrayList<>();
+
+        for (Pair<RexNode,String> n : node.getNamedProjects()) {
+
+            RexNode project = n.getKey();
+
+            if (project instanceof RexLiteral) { //FIXME
+                if (((RexLiteral) project).getValue() == null) {
+                    nullFieldList.add(n.getValue());
+                }
+            }
+
+            if (project instanceof RexCall) { //FIXME
+                ExtensionElem elem = new ExtensionElem(createFunction(project, innerVariablesMap), n.getValue());
+                extensionElemList.add(elem);
+            }
+
+            if (project instanceof RexInputRef) { //FIXME
+                Var var = createExtensionVar(project, innerVariablesMap);
+                if (!(var.getName().equals(n.getValue()))) {
+                    ExtensionElem elem = new ExtensionElem(var, n.getValue());
+                    extensionElemList.add(elem);
+                    renamings.put(n.getValue(), var.getName());
+                }
+
+            }
+        }
+        if (!(extensionElemList.isEmpty())) {
+            input = new Extension(input, extensionElemList);
+        }
+        for (String field: node.getRowType().getFieldNames()) {
+            if (!nullFieldList.contains(field)) {
+                if (renamings.containsKey(field)) {
+                    lst.addElement(new org.eclipse.rdf4j.query.algebra.ProjectionElem(renamings.get(field), field));
+                } else {
+                    lst.addElement(new org.eclipse.rdf4j.query.algebra.ProjectionElem(field));
+                }
+            }
+        }
+
+        return new org.eclipse.rdf4j.query.algebra.Projection(input, lst);
+    }
+
+    public ValueExpr createFunction(RexNode node, Map<Integer, String> innerVariablesMap) {
+
+        if (node instanceof RexCall) {
+            FunctionCall call = new FunctionCall();
+            call.setURI(((RexCall) node).getOperator().getName());
+            List<ValueExpr> args = new ArrayList<>();
+            for (RexNode n: ((RexCall) node).getOperands()) {
+                args.add(createFunction(n, innerVariablesMap));
+            }
+            call.setArgs(args);
+            return call;
+        }
+        if (node instanceof RexInputRef) {
+            return createExtensionVar(node, innerVariablesMap);
+        }
+        if (node instanceof RexLiteral) {
+            RexToValueExprConverter converter = new RexToValueExprConverter(null);
+            Value value = converter.convertLiteral((RexLiteral) node);
+            return new ValueConstant(value);
+        }
+        return null;
+    }
+
+    public Var createExtensionVar(RexNode node, Map<Integer, String> innerVariablesMap) {
+        if (node instanceof RexInputRef) {
+            int index = ((RexInputRef) node).getIndex();
+            return new Var(innerVariablesMap.get(index));
+        }
+        return null;
+    }
+
+    public TupleExpr visit(Intersect node) {
+        List<TupleExpr> inputs = Lists.newArrayList();
+        for (int i = 0; i < node.getInputs().size(); i++) {
+            inputs.add(visitChild(i, node.getInput(i)));
+        }
+
+        TupleExpr expr = inputs.get(0);
+        for (int i = 1; i<node.getInputs().size(); i++) {
+            expr = new org.eclipse.rdf4j.query.algebra.Intersection(expr, inputs.get(i));
+        }
+        return expr;
+    }
+
+    public TupleExpr visit(Minus node) {
+
+        List<TupleExpr> inputs = Lists.newArrayList();
+        for (int i = 0; i < node.getInputs().size(); i++) {
+            inputs.add(visitChild(i, node.getInput(i)));
+        }
+
+        TupleExpr expr = inputs.get(0);
+        for (int i = 1; i<node.getInputs().size(); i++) {
+            expr = new org.eclipse.rdf4j.query.algebra.Difference(expr, inputs.get(i));
+        }
+
+        return expr;
+    }
+
+    public TupleExpr visit(Union node) {
+        List<TupleExpr> inputs = Lists.newArrayList();
+        for (int i = 0; i < node.getInputs().size(); i++) {
+            inputs.add(visitChild(i, node.getInput(i)));
+        }
+
+        TupleExpr expr = inputs.get(0);
+        for (int i = 1; i<node.getInputs().size(); i++) {
+            expr = new org.eclipse.rdf4j.query.algebra.Union(expr, inputs.get(i));
+        }
+
+        return expr;
+    }
+
+    public TupleExpr visit(Sort node) {
+
+        TupleExpr input = visitChild(0, node.getInput());
+
+        if (RelOptUtil.isOrder(node)) {
+            RelDataType rowType = node.getRowType();
+            List<RelFieldCollation> fieldCols = node.getCollation().getFieldCollations();
+            List<org.eclipse.rdf4j.query.algebra.OrderElem> orderElems = Lists.newArrayList();
+            for (RelFieldCollation fieldCol : fieldCols) {
+                String name = rowType.getFieldList().get(fieldCol.getFieldIndex()).getName();
+                Var var = new Var(name);
+                orderElems.add(new org.eclipse.rdf4j.query.algebra.OrderElem(var,
+                        fieldCol.direction == RelFieldCollation.Direction.ASCENDING));
+            }
+            input = new org.eclipse.rdf4j.query.algebra.Order(input, orderElems);
+        }
+
+        if (RelOptUtil.isLimit(node)) {
+            long fetch  = node.fetch == null ? -1 : ((RexLiteral)node.fetch).getValueAs(BigDecimal.class).longValue();
+            long offset = node.offset == null ? -1 : ((RexLiteral)node.offset).getValueAs(BigDecimal.class).longValue();
+            input = new org.eclipse.rdf4j.query.algebra.Slice(input, offset, fetch);
+        }
+
+        return input;
+    }
+
+    public TupleExpr visit(Values node) {
+
+        RelDataType rowType = node.getRowType();
+
+        BindingSetAssignment out = new BindingSetAssignment();
+        out.setBindingNames(Sets.newHashSet(rowType.getFieldNames()));
+
+        ImmutableList.Builder<BindingSet> bindingSets = ImmutableList.builder();
+
+        for (ImmutableList<RexLiteral> tuple : node.getTuples())
+        {
+            int i = 0;
+            QueryBindingSet bs = new QueryBindingSet();
+            for (RexLiteral l : tuple) {
+                String name = rowType.getFieldList().get(i).getName();
+                Value v = RexToValueExprConverter.convertLiteral(l);
+                bs.addBinding(name, v);
+                i++;
+            }
+            bindingSets.add(bs);
+        }
+
+        out.setBindingSets(bindingSets.build());
+
+        return out;
+    }
+
+    public TupleExpr visit(StatementScan node) {
+
+        List<Var> vars = new ArrayList<>();
+
+        for (RelDataTypeField field : node.getRowType().getFieldList()) {
+            vars.add(new Var(field.getName()));
+        }
+
+        org.eclipse.rdf4j.query.algebra.StatementPattern p =
+                new org.eclipse.rdf4j.query.algebra.StatementPattern(vars.get(0), vars.get(1), vars.get(2), vars.get(3));
+
+        return p;
+    }
+
+
+    class NodeContext implements RexToValueExprConverter.Context {
+
+        private RelNode node;
+
+        public NodeContext(RelNode node) {
+            this.node = node;
+        }
+
+        @Override
+        public ValueExpr field(int ordinal) {
+            RelDataType type = this.node.getRowType();
+            String name = type.getFieldList().get(ordinal).getName();
+            return new Var(name);
+        }
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/RexToValueExprConverter.java
+++ b/core/src/main/java/org/semagrow/plan/rel/RexToValueExprConverter.java
@@ -1,0 +1,158 @@
+package org.semagrow.plan.rel;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.*;
+import org.apache.calcite.sql.SqlBinaryOperator;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.util.NlsString;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.algebra.ValueExpr;
+import org.eclipse.rdf4j.query.algebra.Var;
+import org.semagrow.plan.rel.type.RDFTypes;
+
+import java.util.UUID;
+
+/**
+ * Created by antonis on 10/7/2017.
+ */
+public class RexToValueExprConverter extends RexVisitorImpl<ValueExpr> {
+
+    private Context context;
+    private ValueFactory vf = SimpleValueFactory.getInstance();
+
+    protected RexToValueExprConverter(Context context) {
+        super(false);
+        this.context = context;
+    }
+
+    static public ValueExpr convertExpression(RexNode rex, Context ctx)
+    {
+        RexToValueExprConverter converter = new RexToValueExprConverter(ctx);
+        return rex.accept(converter);
+    }
+
+    static public Value convertLiteral(RexLiteral rex)
+    {
+        RexToValueExprConverter converter = new RexToValueExprConverter(null);
+        return converter.convertRexLiteral(rex);
+    }
+
+    private Value convertRexLiteral(RexLiteral literal) {
+
+        if (literal.getType().equals(RDFTypes.BLANK_NODE)) {
+            return null;
+        }
+        if (literal.getType().equals(RDFTypes.IRI_TYPE)) {
+            return convertIri(literal.getValue());
+        }
+        if (literal.getType().equals(RDFTypes.PLAIN_LITERAL)) {
+            return convertLiteral(literal.getValue());
+        }
+        return null;
+    }
+
+    private Value convertLiteral(Comparable value) {
+        return null;
+    }
+
+    private Value convertIri(Comparable value) {
+        if (value instanceof NlsString) {
+            return vf.createIRI(((NlsString) value).getValue());
+        } else {
+            return vf.createIRI(value.toString());
+        }
+    }
+
+
+    @Override
+    public ValueExpr visitLiteral(RexLiteral lit) {
+        String const_name = "const-" + UUID.randomUUID().toString();
+        return new Var(const_name, convertLiteral(lit));
+    }
+
+    @Override
+    public ValueExpr visitCall(RexCall call) {
+        return null;
+        //Lists.transform(call.getOperands();
+        //call.getOperator();
+    }
+
+    @Override
+    public ValueExpr visitInputRef(RexInputRef inputRef) {
+        return context.field(inputRef.getIndex());
+    }
+
+    @Override
+    public ValueExpr visitCorrelVariable(RexCorrelVariable correlVariable) {
+        return null;
+    }
+
+    ValueExpr convertRexNode(RexNode node, RelDataType rowtype) {
+        if (node instanceof RexCall) {
+            return convertRexCall((RexCall) node, rowtype);
+        }
+        return null;
+    }
+
+    ValueExpr convertRexCall(RexCall node, RelDataType rowtype) {
+        if (node.getOperator() instanceof SqlBinaryOperator) {
+            return convertSqlBinaryOperator(node, rowtype);
+        }
+        return null;
+    }
+
+    ValueExpr convertSqlBinaryOperator(RexCall node, RelDataType rowtype) {
+
+        if (node.getOperator().equals(SqlStdOperatorTable.EQUALS)) {
+
+        }
+        if (node.getOperator().equals(SqlStdOperatorTable.GREATER_THAN)) {
+
+        }
+        if (node.getOperator().equals(SqlStdOperatorTable.GREATER_THAN_OR_EQUAL)) {
+
+        }
+        if (node.getOperator().equals(SqlStdOperatorTable.LESS_THAN)) {
+
+        }
+        if (node.getOperator().equals(SqlStdOperatorTable.LESS_THAN_OR_EQUAL)) {
+
+        }
+        if (node.getOperator().equals(SqlStdOperatorTable.NOT_EQUALS)) {
+
+        }
+        return null;
+    }
+
+    /*
+    public static final SqlBinaryOperator CONCAT;
+    public static final SqlBinaryOperator DIVIDE;
+    public static final SqlBinaryOperator DIVIDE_INTEGER;
+    public static final SqlBinaryOperator DOT;
+    public static final SqlBinaryOperator EQUALS;
+    public static final SqlBinaryOperator GREATER_THAN;
+    public static final SqlBinaryOperator IS_DISTINCT_FROM;
+    public static final SqlBinaryOperator IS_NOT_DISTINCT_FROM;
+    public static final SqlBinaryOperator IS_DIFFERENT_FROM;
+    public static final SqlBinaryOperator GREATER_THAN_OR_EQUAL;
+    public static final SqlBinaryOperator IN;
+    public static final SqlBinaryOperator NOT_IN;
+    public static final SqlBinaryOperator LESS_THAN;
+    public static final SqlBinaryOperator LESS_THAN_OR_EQUAL;
+    public static final SqlBinaryOperator MINUS;
+    public static final SqlBinaryOperator MULTIPLY;
+    public static final SqlBinaryOperator NOT_EQUALS;
+    public static final SqlBinaryOperator OR;
+    public static final SqlBinaryOperator PLUS;
+    */
+
+
+    public interface Context {
+        ValueExpr field(int ordinal);
+    }
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/Service.java
+++ b/core/src/main/java/org/semagrow/plan/rel/Service.java
@@ -1,0 +1,81 @@
+package org.semagrow.plan.rel;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelInput;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.SingleRel;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+
+import java.util.List;
+
+/**
+ * Created by angel on 13/7/2017.
+ */
+public abstract class Service extends SingleRel {
+
+    private RexNode ref;
+
+    private boolean silent = false;
+
+    /**
+     * Creates a <code>SingleRel</code>.
+     *
+     * @param cluster Cluster this relational expression belongs to
+     * @param traits
+     * @param input   Input relational expression
+     */
+    protected Service(RelOptCluster cluster,
+                      RelTraitSet traits,
+                      RelNode input,
+                      RexNode ref,
+                      boolean silent)
+    {
+        super(cluster, traits, input);
+
+        this.ref = Preconditions.checkNotNull(ref);
+        this.silent = silent;
+    }
+
+    public Service(RelInput input) {
+        this(input.getCluster(),
+            input.getTraitSet(),
+            input.getInput(),
+            input.getExpression("ref"),
+            input.getBoolean("silent", false));
+    }
+
+    public RexNode getRef() { return ref; }
+
+    @Override public List<RexNode> getChildExps() { return ImmutableList.of(ref); }
+
+    @Override public final RelNode copy(RelTraitSet traitSet,
+                                        List<RelNode> inputs) {
+        return copy(traitSet, sole(inputs), getRef(), isSilent());
+    }
+
+    public abstract Service copy(RelTraitSet traitSet, RelNode input,
+                                RexNode ref, boolean silent);
+
+    @Override public RelNode accept(RexShuttle shuttle) {
+        RexNode ref = shuttle.apply(this.ref);
+        if (this.ref == ref) {
+            return this;
+        }
+        return copy(traitSet, getInput(), ref, isSilent());
+    }
+
+    @Override public RelWriter explainTerms(RelWriter pw) {
+        return super.explainTerms(pw)
+                .item("ref", getRef())
+                .itemIf("silent", isSilent(), isSilent());
+    }
+
+    public boolean isSilent() { return silent; }
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/StatementScan.java
+++ b/core/src/main/java/org/semagrow/plan/rel/StatementScan.java
@@ -1,0 +1,72 @@
+package org.semagrow.plan.rel;
+
+import com.google.common.base.Preconditions;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.AbstractRelNode;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.semagrow.plan.rel.schema.RelOptDataset;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by angel on 2/7/2017.
+ */
+public abstract class StatementScan extends AbstractRelNode {
+
+    private RelOptDataset dataset;
+
+    protected StatementScan(RelOptCluster cluster,
+                            RelTraitSet traitSet,
+                            RelOptDataset dataset)
+    {
+        super(cluster, traitSet);
+        this.dataset = Preconditions.checkNotNull(dataset);
+    }
+
+    @Override public double estimateRowCount(RelMetadataQuery mq) {
+        return dataset.getRowCount();
+    }
+
+    @Override protected RelDataType deriveRowType() {
+        return dataset.getRowType(getCluster().getTypeFactory());
+    }
+
+    @Override public RelWriter explainTerms(RelWriter pw) {
+        return super.explainTerms(pw)
+                .item("dataset", dataset.toString());
+    }
+
+    public RelOptDataset getDataset() { return dataset; }
+
+    public RelNode projectAndFilter(ImmutableBitSet fieldsUsed,
+                           List<String> nameList,
+                           RexNode condition,
+                           RelBuilder relBuilder) {
+
+        final List<RexNode> exprList = new ArrayList<>();
+        final RexBuilder rexBuilder = getCluster().getRexBuilder();
+
+        assert fieldsUsed.cardinality() == nameList.size();
+
+        for (int i : fieldsUsed) {
+            exprList.add(rexBuilder.makeInputRef(this, i));
+        }
+
+        return relBuilder
+                .push(this)
+                .filter(condition)
+                .project(exprList, nameList)
+                .build();
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/TupleExprToRelConverter.java
+++ b/core/src/main/java/org/semagrow/plan/rel/TupleExprToRelConverter.java
@@ -1,0 +1,951 @@
+package org.semagrow.plan.rel;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.*;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.*;
+import org.apache.calcite.rel.core.*;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.*;
+import org.apache.calcite.sql.SemiJoinType;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql2rel.DeduplicateCorrelateVariables;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.algebra.*;
+import org.apache.calcite.rel.logical.*;
+import org.eclipse.rdf4j.query.algebra.Filter;
+import org.eclipse.rdf4j.query.algebra.Join;
+import org.eclipse.rdf4j.query.algebra.Sample;
+import org.eclipse.rdf4j.query.algebra.Union;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
+import org.semagrow.plan.rel.logical.LogicalService;
+import org.semagrow.plan.rel.logical.LogicalStatementScan;
+import org.semagrow.plan.rel.schema.AbstractDataset;
+import org.semagrow.plan.rel.schema.RelOptDataset;
+import org.semagrow.plan.rel.schema.RelOptDatasetImpl;
+import org.semagrow.plan.rel.type.RDFTypes;
+import org.semagrow.plan.rel.type.RdfDataTypeFactory;
+
+import java.math.BigDecimal;
+import java.util.*;
+
+/**
+ * Created by angel on 30/6/2017.
+ */
+public class TupleExprToRelConverter {
+
+    private RelOptCluster cluster;
+    private RdfDataTypeFactory typeFactory;
+    private RdfRexBuilder rexBuilder;
+    private ValueExprToRexConverter exprConverter;
+    private CatalogReader catalogReader;
+
+    private final Map<CorrelationId, DeferredLookup> mapCorrelToDeferred =
+            new HashMap<>();
+
+    public TupleExprToRelConverter(RelOptCluster cluster, CatalogReader catalogReader) {
+        this.cluster = Preconditions.checkNotNull(cluster);
+        this.typeFactory = (RdfDataTypeFactory) cluster.getTypeFactory();
+        this.rexBuilder = new RdfRexBuilder(this.typeFactory);
+        this.exprConverter = new ValueExprToRexConverter(cluster);
+        this.catalogReader = Preconditions.checkNotNull(catalogReader);
+    }
+
+    public RelRoot convertQuery(QueryRoot queryNode) {
+
+        RelNode result = convertQueryRecursively(Scopes.empty(), queryNode.getArg());
+
+        RelCollation collation = RelCollations.EMPTY;
+
+        if (isOrdered(result))
+            collation = requiredCollation(result);
+
+        return RelRoot.of(result, result.getRowType(), SqlKind.SELECT)
+                .withCollation(collation);
+    }
+
+
+    private RelCollation requiredCollation(RelNode r) {
+        if (r instanceof Sort) {
+            RelCollation col =  ((Sort) r).collation;
+            if (col.equals(RelCollations.EMPTY))
+                return requiredCollation(((Sort)r).getInput());
+            else
+                return col;
+        }
+
+        if (r instanceof Project) {
+            return requiredCollation(((Project) r).getInput());
+        }
+
+        throw new AssertionError();
+    }
+
+    private boolean isOrdered(RelNode r) {
+        if (r instanceof Sort) {
+            return true;
+        } else if (r instanceof Project)
+            return isOrdered(((Project)r).getInput());
+        else
+            return false;
+    }
+
+    private RelNode convertQueryRecursively(Scope scope, TupleExpr query) {
+
+        RelNode n = convertTupleExpr(scope, query);
+
+        n = injectCorrelatedJoinConditions(scope, n, n.getRowType().getFieldNames());
+
+        return n;
+    }
+
+    private RelNode convertTupleExpr(Scope scope, TupleExpr query) {
+
+        if (query instanceof Union)
+            return convertUnion(scope, (Union)query);
+        else if (query instanceof Difference)
+            return convertDifference(scope, (Difference)query);
+        else if (query instanceof Intersection)
+            return convertIntersection(scope, (Intersection)query);
+        else if (query instanceof Projection)
+            return convertProject(scope, (Projection)query);
+        else if (query instanceof Extension)
+            return convertExtension(scope, (Extension)query);
+        else if (query instanceof Filter)
+            return convertFilter(scope, (Filter)query);
+        else if (query instanceof Distinct)
+            return convertDistinct(scope, (Distinct)query);
+        else if (query instanceof Group)
+            return convertAgg(scope, (Group)query);
+        else if (query instanceof Join)
+            return convertJoin(scope, (Join)query);
+        else if (query instanceof LeftJoin)
+            return convertLeftJoin(scope, (LeftJoin)query);
+        else if (query instanceof StatementPattern)
+            return convertPattern(scope, (StatementPattern)query);
+        else if (query instanceof BindingSetAssignment)
+            return convertBindingSetAssignment(scope, (BindingSetAssignment)query);
+        else if (query instanceof Order)
+            return convertOrder(scope, (Order)query, null, null);
+        else if (query instanceof Slice)
+            return convertLimit(scope, (Slice)query);
+        else if (query instanceof org.eclipse.rdf4j.query.algebra.Service)
+            return convertService(scope, (org.eclipse.rdf4j.query.algebra.Service)query);
+        else
+            return null;
+    }
+
+    private RelNode convertPattern(Scope scope, StatementPattern query)
+    {
+        //RelOptDataset dataset = RelOptDatasetImpl.create(null, new AbstractDataset());
+
+        RelOptDataset dataset = catalogReader.getDataset();
+
+        Var[] vars = new Var[] {
+                query.getSubjectVar(),
+                query.getPredicateVar(),
+                query.getObjectVar(),
+                query.getContextVar() };
+
+        ImmutableList.Builder<RexNode> conditions = ImmutableList.builder();
+        ImmutableBitSet.Builder columns = ImmutableBitSet.builder();
+
+        Map<String, Integer> varNamesMap = new HashMap<>();
+
+        for (int i = 0; i < vars.length; i++) {
+            if (vars[i] != null) {
+                if (vars[i].isConstant()) {
+                    assert vars[i].getValue() != null;
+                    List<RexNode> operands = new ArrayList<>();
+                    RexLiteral lit = makeLiteral(vars[i].getValue());
+                    operands.add(rexBuilder.makeInputRef(lit.getType(), i));
+                    operands.add(lit);
+                    conditions.add(rexBuilder.makeCall(SqlStdOperatorTable.EQUALS,operands));
+                } else {
+                    if (varNamesMap.containsKey(vars[i].getName())) {
+                        // must include an equality of varNamesMap.get(vars[i].getName()) and i
+                        List<RexNode> operands = new ArrayList<>();
+                        operands.add(rexBuilder.makeInputRef(RDFTypes.IRI_TYPE, varNamesMap.get(vars[i].getName())));
+                        operands.add(rexBuilder.makeInputRef(RDFTypes.IRI_TYPE, i));
+                        conditions.add(rexBuilder.makeCall(SqlStdOperatorTable.EQUALS,operands));
+                    } else {
+                        columns.set(i);
+                        varNamesMap.put(vars[i].getName(), i);
+                    }
+                }
+            }
+        }
+
+        return LogicalStatementScan.create(cluster, dataset)
+                .projectAndFilter(
+                        columns.build(),
+                        ImmutableList.copyOf(varNamesMap.keySet()),
+                        RexUtil.composeConjunction(rexBuilder,conditions.build(),false),
+                        RelFactories.LOGICAL_BUILDER.create(cluster,null));
+    }
+
+    private RelNode convertDifference(Scope scope, Difference node) {
+        RelNode left = convertTupleExpr(scope, node.getLeftArg());
+        RelNode right = convertTupleExpr(scope, node.getRightArg());
+
+        return LogicalMinus.create(ImmutableList.of(left,right), true);
+    }
+
+    private RelNode convertUnion(Scope scope, Union node) {
+
+        RelNode left = convertTupleExpr(scope, node.getLeftArg());
+        RelNode right = convertTupleExpr(scope, node.getRightArg());
+
+        RelDataType unionType = mergeUnionType(left.getRowType(), right.getRowType());
+
+        left = projectOrNull(left, unionType);
+        right = projectOrNull(right, unionType);
+
+        return LogicalUnion.create(ImmutableList.of(left,right), true);
+    }
+
+    private RelNode convertService(Scope scope, org.eclipse.rdf4j.query.algebra.Service node) {
+        RelNode input = convertTupleExpr(scope, node.getArg());
+        RexNode ref = convertExpression(Scopes.delegate(scope), node.getServiceRef());
+        return LogicalService.create(input, ref, node.isSilent());
+    }
+
+    private RelNode projectOrNull(RelNode n, RelDataType unionType) {
+
+        RelDataType inputType = n.getRowType();
+        ImmutableList.Builder<String> fields = ImmutableList.builder();
+        ImmutableList.Builder<RexNode> exprs = ImmutableList.builder();
+
+        boolean hasNulls = false;
+
+        for (RelDataTypeField f : unionType.getFieldList()) {
+            fields.add(f.getName());
+            RelDataTypeField ff = inputType.getField(f.getName(), false, false);
+
+            if (ff != null) {
+                exprs.add(rexBuilder.makeInputRef(n, ff.getIndex()));
+            } else {
+                hasNulls = true;
+                exprs.add(rexBuilder.constantNull());
+            }
+        }
+
+        if (hasNulls)
+            return RelFactories.DEFAULT_PROJECT_FACTORY
+                .createProject(n, exprs.build(), fields.build());
+        else
+            return n;
+    }
+
+    private RelDataType mergeUnionType(RelDataType t1, RelDataType t2) {
+        List<String> common = Lists.newArrayList(t1.getFieldNames());
+        common.retainAll(t2.getFieldNames());
+        List<String> all = Lists.newArrayList(t1.getFieldNames());
+        all.addAll(t2.getFieldNames());
+        List<String> notcommon = Lists.newArrayList(all);
+        notcommon.removeAll(common);
+
+        RelDataTypeFactory.FieldInfoBuilder type = typeFactory.builder();
+        for (String name : common) {
+            type.add(t1.getField(name, false, false));
+        }
+
+        for (String name : notcommon) {
+            RelDataTypeField f = t1.getField(name, false, false);
+            if (f == null) {
+                f = t2.getField(name, false, false);
+            }
+            assert f != null;
+            type.add(f);
+        }
+
+        return type.build();
+    }
+
+    private RelNode convertIntersection(Scope scope, Intersection node) {
+        RelNode left  = convertTupleExpr(scope, node.getLeftArg());
+        RelNode right = convertTupleExpr(scope, node.getRightArg());
+
+        return LogicalIntersect.create(ImmutableList.of(left,right), true);
+    }
+
+    private RelNode convertJoin(Scope scope, Join node) {
+        RelNode leftRel  = convertTupleExpr(scope, node.getLeftArg());
+        Scope leftScope =  Scopes.of(leftRel, scope);
+        RelNode rightRel = convertTupleExpr(leftScope,  node.getRightArg());
+
+        List<String> columnNames = deriveNaturalJoinColumnList(leftRel.getRowType(), rightRel.getRowType());
+
+        RexNode condition = convertUsing(leftRel.getRowType(), rightRel.getRowType(), columnNames);
+
+        return createJoin(scope, leftScope, leftRel, rightRel, condition, JoinRelType.INNER);
+    }
+
+    private RelNode convertLeftJoin(Scope scope, LeftJoin node) {
+        RelNode leftRel  = convertTupleExpr(scope, node.getLeftArg());
+        Scope leftScope =  Scopes.of(leftRel, scope); // FIXME: leftScope and rightScope must be local to condition and generate InputRef.
+        RelNode rightRel = convertTupleExpr(leftScope,  node.getRightArg());
+
+        List<String> columnNames = deriveNaturalJoinColumnList(leftRel.getRowType(), rightRel.getRowType());
+
+        RexNode condition = convertUsing(leftRel.getRowType(), rightRel.getRowType(), columnNames);
+
+        if (node.hasCondition()) {
+
+            RexNode rightCond = convertExpression(Scopes.of(ImmutableList.of(leftRel, rightRel), scope), node.getCondition());
+            // review: might contain inner queries (?)
+            //rightRel = RelFactories.DEFAULT_FILTER_FACTORY.createFilter(rightRel, rightCond);
+            condition = RelOptUtil.andJoinFilters(rexBuilder, condition, rightCond);
+        }
+
+        return createJoin(scope, leftScope, leftRel, rightRel, condition, JoinRelType.LEFT);
+    }
+
+    private RelNode createJoin(Scope scope,
+                               Scope leftScope,
+                               RelNode leftRel,
+                               RelNode rightRel,
+                               RexNode condition,
+                               JoinRelType joinType) {
+
+        CorrelateUse p = getCorrelateUse(leftScope, rightRel);
+
+        if (p != null) {
+            rightRel = p.r;
+
+            RelNode corr =  RelFactories.DEFAULT_CORRELATE_FACTORY
+                    .createCorrelate(leftRel,
+                            rightRel,
+                            p.id,
+                            p.requiredColumns,
+                            SemiJoinType.of(joinType));
+
+            if (!condition.isAlwaysTrue())
+                return RelFactories.DEFAULT_FILTER_FACTORY.createFilter(corr, condition);
+
+
+            return corr;
+
+        } else {
+
+            org.apache.calcite.rel.core.Join r = (org.apache.calcite.rel.core.Join) RelFactories.DEFAULT_JOIN_FACTORY
+                    .createJoin(leftRel,
+                                rightRel,
+                                condition,
+                                ImmutableSet.of(),
+                                joinType,
+                                false);
+
+            return RelOptUtil.pushDownJoinConditions(r);
+        }
+    }
+
+
+    public static List<String> deriveNaturalJoinColumnList(
+            RelDataType leftRowType,
+            RelDataType rightRowType) {
+        final List<String> naturalColumnNames = new ArrayList<>();
+        final List<String> leftNames = leftRowType.getFieldNames();
+        final List<String> rightNames = rightRowType.getFieldNames();
+        for (String name : leftNames) {
+            if ((Collections.frequency(leftNames, name) == 1)
+                    && (Collections.frequency(rightNames, name) == 1)) {
+                naturalColumnNames.add(name);
+            }
+        }
+        return naturalColumnNames;
+    }
+
+
+    private RexNode convertUsing(RelDataType leftRowType, RelDataType rightRowType, List<String> nameList) {
+        final List<RexNode> list = Lists.newArrayList();
+        for (String name : nameList) {
+            List<RexNode> operands = new ArrayList<>();
+            int offset = 0;
+            for (RelDataType rowType : ImmutableList.of(leftRowType,
+                    rightRowType)) {
+                final RelDataTypeField field = rowType.getField(name,false,false);
+                operands.add(
+                        rexBuilder.makeInputRef(field.getType(),
+                                offset + field.getIndex()));
+                offset += rowType.getFieldList().size();
+            }
+            list.add(rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, operands));
+        }
+        // maybe use RelOptUtil.createEquiJoinCondition
+        return RexUtil.composeConjunction(rexBuilder, list, false);
+    }
+
+    private RelNode convertLimit(Scope scope, Slice node) {
+        BigDecimal fetch = BigDecimal.valueOf(node.getLimit());
+        BigDecimal offset = BigDecimal.valueOf(node.getOffset());
+
+        if (node.getArg() instanceof Order) {
+            return convertOrder(scope, (Order)node.getArg(), offset, fetch);
+        } else {
+            RelNode input = convertTupleExpr(scope, node.getArg());
+            return RelFactories.DEFAULT_SORT_FACTORY
+                    .createSort(input, RelCollations.EMPTY,
+                            rexBuilder.makeExactLiteral(offset),
+                            rexBuilder.makeExactLiteral(fetch));
+        }
+    }
+
+    private RelNode convertOrder(Scope scope, Order node, BigDecimal offset, BigDecimal fetch) {
+
+        RelNode input = convertTupleExpr(scope, node.getArg());
+
+        List<Pair<RexNode,String>> extensions = Lists.newArrayList();
+        Map<OrderElem, String> mapElemToNames = Maps.newHashMap();
+
+        List<String> columns = Lists.newArrayList(input.getRowType().getFieldNames());
+
+        for (OrderElem elem : node.getElements()) {
+            if (elem.getExpr() instanceof Var && !((Var)elem.getExpr()).isConstant()) {
+                mapElemToNames.put(elem, ((Var)elem.getExpr()).getName());
+            } else {
+                String name = createUniqueColumnName(elem.getExpr(), columns);
+                columns.add(name);
+                mapElemToNames.put(elem, name);
+                extensions.add(Pair.of(convertExpression(Scopes.of(input), elem.getExpr()), name));
+            }
+        }
+
+        if (!extensions.isEmpty()) {
+            ImmutableList.Builder<Pair<RexNode,String>> projections = ImmutableList.builder();
+
+            RelDataType type = input.getRowType();
+
+            for (RelDataTypeField f : type.getFieldList())
+                projections.add(Pair.of(rexBuilder.makeInputRef(input,f.getIndex()), f.getName()));
+
+            projections.addAll(extensions);
+
+            input = RelOptUtil.createProject(input, projections.build(), false);
+        }
+
+        List<RelFieldCollation> fieldCollations = Lists.newArrayList();
+        RelDataType type = input.getRowType();
+        for (OrderElem elem : node.getElements()) {
+
+            String fieldName = mapElemToNames.get(elem);
+            assert fieldName != null;
+
+            RelFieldCollation.Direction direction = (elem.isAscending()) ?
+                    RelFieldCollation.Direction.ASCENDING : RelFieldCollation.Direction.DESCENDING;
+
+            RelFieldCollation.NullDirection nullDirection = elem.isAscending() ?
+                    RelFieldCollation.NullDirection.FIRST : RelFieldCollation.NullDirection.LAST;
+
+            RelDataTypeField f = type.getField(fieldName, false, false);
+            assert f != null;
+            fieldCollations.add(new RelFieldCollation(f.getIndex(), direction, nullDirection));
+        }
+
+        RelCollation collation = RelCollations.of(fieldCollations);
+        collation = cluster.traitSet().canonize(collation);
+
+
+        input = RelFactories.DEFAULT_SORT_FACTORY
+                .createSort(input, collation,
+                        offset == null ? null : rexBuilder.makeExactLiteral(offset),
+                        fetch == null ? null  : rexBuilder.makeExactLiteral(fetch));
+
+        if (extensions.isEmpty())
+            return input;
+        else {
+            List<RexNode> fields = Lists.newArrayList();
+            for (String name : columns) {
+                RelDataTypeField f = type.getField(name, false, false);
+                fields.add(rexBuilder.makeInputRef(input, f.getIndex()));
+            }
+
+            return RelFactories.DEFAULT_PROJECT_FACTORY.createProject(input, fields, columns);
+        }
+    }
+
+    protected String createUniqueColumnName(ValueExpr e, List<String> names) {
+        String nameBase = "EXPR";
+        for (int j = 0; ; j++) {
+            String name = nameBase + j;
+            if (!names.contains(name))
+                return name;
+        }
+    }
+
+    protected RelNode convertDistinct(Scope scope, Distinct node) {
+        RelNode input = convertTupleExpr(scope, node.getArg());
+        return RelOptUtil.createDistinctRel(input);
+    }
+
+    protected RelNode convertAgg(Scope scope, Group node) {
+        RelNode input = convertTupleExpr(scope, node.getArg());
+
+        List<String> nonGrouped = Lists.newArrayList(input.getRowType().getFieldNames());
+        nonGrouped.removeAll(node.getGroupBindingNames());
+
+        input = injectCorrelatedJoinConditions(scope, input, nonGrouped);
+
+        ImmutableBitSet.Builder groupSet = ImmutableBitSet.builder();
+
+        Scope localScope = Scopes.of(input);
+
+        for (String groupName : node.getGroupBindingNames()) {
+            Scope.ResolvedImpl result = new Scope.ResolvedImpl();
+            localScope.resolve(groupName, result);
+            assert result.resolved;
+            int ordinal = result.field.getIndex();
+            groupSet.set(ordinal);
+        }
+
+        List<AggregateCall> aggCalls = new ArrayList<>();
+
+        for (GroupElem elem : node.getGroupElements()) {
+            AggregateCall aggCall = convertAggCall(Scopes.of(input), input, elem.getOperator(), elem.getName());
+            aggCalls.add(aggCall);
+        }
+
+        return RelFactories.DEFAULT_AGGREGATE_FACTORY
+                .createAggregate(input,false, groupSet.build(),null, aggCalls);
+    }
+
+    private AggregateCall convertAggCall(Scope scope, RelNode input, AggregateOperator operator, String name) {
+        boolean distinct = operator.isDistinct();
+
+        List<Integer> argList = ImmutableList.of();
+
+        ValueExpr arg = ((UnaryValueOperator)operator).getArg();
+
+        // if arg is more complex expression than a new row-level calculation must be added a new column introduced
+        if (arg instanceof Var) {
+            if (!((Var) arg).isConstant()) {
+                Scope.ResolvedImpl result = new Scope.ResolvedImpl();
+                scope.resolve(((Var)arg).getName(), result);
+                assert result.resolved && result.scope == scope;
+                argList = ImmutableList.of(result.field.getIndex());
+            }
+        }
+
+        ImmutableMap.Builder<Class<?>, SqlAggFunction> mapAggFuns = ImmutableMap.builder();
+
+        mapAggFuns.put(Avg.class, SqlStdOperatorTable.AVG);
+        mapAggFuns.put(Sum.class, SqlStdOperatorTable.SUM);
+        mapAggFuns.put(Count.class, SqlStdOperatorTable.COUNT);
+        mapAggFuns.put(Min.class, SqlStdOperatorTable.MIN);
+        mapAggFuns.put(Max.class, SqlStdOperatorTable.MAX);
+        mapAggFuns.put(Sample.class, SqlStdOperatorTable.COVAR_SAMP);
+        //mapAggFuns.put(GroupConcat.class, SqlStdOperatorTable.)
+
+        SqlAggFunction aggFun = mapAggFuns.build().get(operator.getClass());
+
+        return AggregateCall.create(aggFun, distinct, argList, -1, 0,  input,null, name);
+    }
+
+    protected RelNode convertFilter(Scope scope, Filter node) {
+        // FIXME: check whether this is a theta-join
+        RelNode input = convertTupleExpr(scope, node.getArg());
+        Scope expScope = Scopes.of(input, scope);
+        RexNode cond = convertExpression(expScope, node.getCondition());
+
+        RelNode filter = RelFactories.DEFAULT_FILTER_FACTORY.createFilter(input,cond);
+        CorrelateUse p = getCorrelateUse(expScope, filter); // REVIEW scope
+        if (p != null) {
+            assert p.r instanceof org.apache.calcite.rel.core.Filter;
+            org.apache.calcite.rel.core.Filter f = (org.apache.calcite.rel.core.Filter) p.r;
+            filter = LogicalFilter.create(f.getInput(), f.getCondition(), ImmutableSet.of(p.id));
+        }
+        return filter;
+    }
+
+    protected RelNode convertProject(Scope scope, Projection node)
+    {
+        RelNode input = convertTupleExpr(scope, node.getArg());
+
+        ImmutableList.Builder<Pair<RexNode,String>> projectionElems = ImmutableList.builder();
+
+        List<String> nonProjected = Lists.newArrayList(input.getRowType().getFieldNames());
+
+        for (ProjectionElem elem : node.getProjectionElemList().getElements())
+            nonProjected.remove(elem.getSourceName());
+
+        input = injectCorrelatedJoinConditions(scope, input, nonProjected);
+
+        Scope localScope = Scopes.of(input);
+
+        for (ProjectionElem elem : node.getProjectionElemList().getElements())  {
+
+            RexNode exp;
+
+            Scope.ResolvedImpl result = new Scope.ResolvedImpl();
+            localScope.resolve(elem.getSourceName(),result);
+            assert result.resolved;
+            exp = rexBuilder.makeInputRef(result.rel, result.field.getIndex());
+
+            projectionElems.add(Pair.of(exp, elem.getTargetName()));
+        }
+
+        return RelOptUtil.createProject(input, projectionElems.build(), false);
+    }
+
+    protected RelNode convertExtension(Scope scope, Extension node) {
+
+        RelNode input = convertTupleExpr(scope, node.getArg());
+
+        RelDataType rowType = input.getRowType();
+
+        ImmutableList.Builder<Pair<RexNode,String>> extensionElems = ImmutableList.builder();
+
+        extensionElems.addAll(Lists.<RelDataTypeField, Pair<RexNode,String>>transform(
+                rowType.getFieldList(),
+                f -> Pair.of(rexBuilder.makeInputRef(f.getType(), f.getIndex()),
+                             f.getName())));
+
+        boolean hasExtensions = false;
+
+        for (ExtensionElem elem : node.getElements()) {
+            if (!(elem.getExpr() instanceof AggregateOperator)) {
+                RexNode exp = convertExpression(Scopes.of(input, scope), elem.getExpr());
+                extensionElems.add(Pair.of(exp, elem.getName()));
+                hasExtensions = true;
+            }
+        }
+        if (hasExtensions)
+            return RelOptUtil.createProject(input, extensionElems.build(), false);
+        else
+            return input;
+    }
+
+    protected RelNode convertBindingSetAssignment(Scope scope, BindingSetAssignment node) {
+        ImmutableList.Builder<ImmutableList<RexLiteral>> builder = ImmutableList.builder();
+
+        ImmutableList<String> fieldNames = ImmutableList.copyOf(node.getBindingNames());
+
+        RelDataTypeFactory.FieldInfoBuilder typeBuilder = cluster.getTypeFactory().builder();
+
+        for (String name : fieldNames) {
+            typeBuilder.add(name, SqlTypeName.ANY);
+        }
+
+        RelDataType rowType = typeBuilder.build();
+
+        for (BindingSet bs : node.getBindingSets()) {
+            ImmutableList<RexLiteral> tuple = ImmutableList.copyOf(fieldNames.stream()
+                    .map(n -> makeLiteral(bs.getBinding(n).getValue())).iterator());
+            builder.add(tuple);
+        }
+        return RelFactories.DEFAULT_VALUES_FACTORY.createValues(cluster, rowType, builder.build());
+    }
+
+    protected RexNode convertExpression(Scope scope, ValueExpr expr) {
+        ValueExprConverter exprConverter = new ValueExprConverter(scope);
+        return exprConverter.convertExpression(expr);
+    }
+
+    private RelNode injectCorrelatedJoinConditions(Scope scope, RelNode input, List<String> fieldNames) {
+
+        final List<RexNode> list = Lists.newArrayList();
+
+        RelDataType inputType = input.getRowType();
+
+        for (String n : fieldNames) {
+            Scope.ResolvedImpl result = new Scope.ResolvedImpl();
+            scope.resolve(n, result);
+
+            if (result.resolved) {
+
+                List<RexNode> operands = Lists.newArrayList();
+
+                CorrelationId id = cluster.createCorrel();
+                RelDataType corrType = result.rel.getRowType();
+                RexNode corrExp = rexBuilder.makeCorrel(corrType, id);
+
+                DeferredLookup lookup = new DeferredLookup(id, result.scope, n, result.field.getIndex());
+                mapCorrelToDeferred.put(id, lookup);
+
+                operands.add(rexBuilder.makeFieldAccess(corrExp, result.field.getIndex()));
+
+                RelDataTypeField field = inputType.getField(n, false, false);
+
+                operands.add(
+                        rexBuilder.makeInputRef(input, field.getIndex()));
+
+                list.add(rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, operands));
+            }
+        }
+
+        RexNode condition = RexUtil.composeConjunction(rexBuilder, list, true);
+
+        if (condition != null)
+            input = RelFactories.DEFAULT_FILTER_FACTORY.createFilter(input, condition);
+
+        return input;
+    }
+
+    protected RexLiteral makeLiteral(Value v) {
+        if (v instanceof Literal) {
+            return (RexLiteral) rexBuilder.makeRDFLiteral((Literal)v);
+        }
+        else
+            return (RexLiteral) rexBuilder.makeRDFResource((Resource)v);
+    }
+
+    private CorrelateUse getCorrelateUse(Scope scope, RelNode node) {
+
+        Set<CorrelationId> correlatedVariables = RelOptUtil.getVariablesUsed(node);
+
+        if (correlatedVariables.isEmpty())
+            return null;
+
+        ImmutableBitSet.Builder columns = ImmutableBitSet.builder();
+
+        List<CorrelationId> correlNames = Lists.newArrayList();
+
+        for (CorrelationId id : correlatedVariables) {
+
+            DeferredLookup lookup = mapCorrelToDeferred.get(id);
+
+            if (lookup.scope.equals(scope)) {
+                correlNames.add(id);
+                columns.set(lookup.fieldOrd);
+            }
+        }
+
+        if (correlNames.isEmpty())
+            return null;
+
+        RelNode r = node;
+
+        if (correlNames.size() > 1) {
+            r = DeduplicateCorrelateVariables.go(rexBuilder, correlNames.get(0), Util.skip(correlNames), r);
+        }
+
+        return new CorrelateUse(correlNames.get(0), columns.build(), r);
+    }
+
+    class ValueExprConverter extends AbstractQueryModelVisitor<RuntimeException>
+            implements ValueExprToRexConverter.ValueExprConverterContext
+    {
+        private RexNode output;
+        private Scope scope;
+
+        public ValueExprConverter(Scope scope) {
+            setScope(scope);
+        }
+
+        public void setScope(Scope scope) {
+            this.scope = scope;
+        }
+
+        public RexNode convertExpression(ValueExpr exp) {
+            ValueExprConverter converter = new ValueExprConverter(this.scope);
+            exp.visit(converter);
+            return converter.output;
+        }
+
+        public RexNode convertSubQuery(TupleExpr query) {
+            RelNode rel = convertQueryRecursively(scope, query);
+            return RexSubQuery.scalar(rel);
+        }
+
+        @Override public void meet(Var v) {
+
+            if (v.isConstant()) {
+                output = makeLiteral(v.getValue());
+                return;
+            }
+
+            String varName = v.getName();
+
+            /* resolve varName as local (i.e. column of the direct input) or global (i.e. set from
+               a parent. If resolved failed, then something is wrong.
+               If variable is local create an InputRef otherwise create a correlationId to the relation
+               assosiated with the resolved variable, find its type and then create a FieldAccess to that correlation.
+               useful for subqueries and leftjoin.
+            */
+
+            Scope.ResolvedImpl result = new Scope.ResolvedImpl();
+            scope.resolve(varName, result);
+
+            if (result.resolved) {
+
+                if (result.scope == scope) {
+                    // this is local
+                    output = rexBuilder.makeInputRef(result.rel, result.field.getIndex());
+                } else {
+                    CorrelationId id = cluster.createCorrel();
+                    RelDataType corrType = result.rel.getRowType();
+                    RexNode corrExp = rexBuilder.makeCorrel(corrType, id);
+                    DeferredLookup lookup = new DeferredLookup(id, result.scope, varName, result.field.getIndex());
+                    mapCorrelToDeferred.put(id, lookup);
+                    output = rexBuilder.makeFieldAccess(corrExp, result.field.getIndex());
+                }
+            }
+        }
+
+        @Override public void meet(ValueConstant node) {
+            output = makeLiteral(node.getValue());
+        }
+
+        @Override public void meet(In node) {
+            RexNode arg = convertExpression(node.getArg());
+            RelNode rel = convertQueryRecursively(scope, node.getSubQuery());
+            output = RexSubQuery.in(rel, ImmutableList.of(arg));
+        }
+
+        @Override public void meet(Exists node) {
+            RelNode rel = convertQueryRecursively(scope, node.getSubQuery());
+            output = RexSubQuery.exists(rel);
+        }
+
+        @Override protected void meetNode(QueryModelNode node) {
+            if (node instanceof ValueExpr)
+                output = exprConverter.convertExpr((ValueExpr)node, this);
+            else
+                super.meetNode(node);
+        }
+    }
+
+    interface Scope {
+
+        void resolve(String name, Resolved result);
+
+        Scope getParent();
+
+        interface Resolved {
+
+            void success(Scope scope, RelNode rel, RelDataTypeField field);
+            void failed();
+        }
+
+        class ResolvedImpl implements Resolved {
+
+            boolean resolved;
+            Scope scope;
+            RelNode rel;
+            RelDataTypeField field;
+
+            public void success(Scope scope, RelNode rel, RelDataTypeField field){
+                this.resolved = true;
+                this.scope = scope;
+                this.rel = rel;
+                this.field = field;
+            }
+
+            public void failed() {
+                resolved = false;
+            }
+        }
+    }
+
+    public static class EmptyScope implements Scope {
+
+        public void resolve(String name, Resolved result) {
+            result.failed();
+        }
+
+        public Scope getParent() { return null; }
+    }
+
+    public static class DelegatingScope implements Scope {
+
+        private Scope parentScope;
+
+        public DelegatingScope(Scope delegate) {
+            parentScope = delegate;
+        }
+
+        public void resolve(String name, Resolved result) {
+            if (parentScope != null) {
+                parentScope.resolve(name, result);
+            } else {
+                result.failed();
+            }
+
+        }
+        public Scope getParent() { return parentScope; }
+
+    }
+
+    public static class RelNodeScope extends  DelegatingScope {
+
+        private ImmutableList<RelNode> input;
+
+        public RelNodeScope(Scope delegate, List<RelNode> input) {
+            super(delegate);
+            this.input = ImmutableList.copyOf(input);
+        }
+
+        public void resolve(String name, Resolved result) {
+
+            for (RelNode input : this.input) {
+                RelDataType type = input.getRowType();
+                RelDataTypeField field = type.getField(name, false, false);
+                if (field != null) {
+                    result.success(this, input, field);
+                    return;
+                }
+            }
+            super.resolve(name, result);
+        }
+    }
+
+    public static class Scopes {
+
+        static Scope empty() { return new EmptyScope(); }
+
+        static Scope of(RelNode rel) {
+            return new RelNodeScope(null, ImmutableList.of(rel));
+        }
+
+        static Scope of(List<RelNode> rel) { return new RelNodeScope(null, rel); }
+
+        static Scope of(RelNode rel, Scope parent) {
+            return new RelNodeScope(parent, ImmutableList.of(rel));
+        }
+
+        static Scope of(List<RelNode> rel, Scope parent) { return new RelNodeScope(parent, rel); }
+
+        static Scope delegate(Scope parent) { return new RelNodeScope(parent, ImmutableList.of()); }
+
+    }
+
+    static class CorrelateUse {
+
+        CorrelationId id;
+        ImmutableBitSet requiredColumns;
+        RelNode r;
+
+        CorrelateUse(CorrelationId id, ImmutableBitSet columns, RelNode r) {
+            this.id = id;
+            this.requiredColumns = columns;
+            this.r = r;
+        }
+    }
+
+    static class DeferredLookup {
+        CorrelationId id;
+        Scope scope;
+        String originalFieldName;
+        int fieldOrd;
+
+        DeferredLookup(CorrelationId id, Scope scope, String originalFieldName, int fieldOrd) {
+            this.id = id;
+            this.scope = scope;
+            this.originalFieldName = originalFieldName;
+            this.fieldOrd = fieldOrd;
+        }
+    }
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/ValueExprToRexConverter.java
+++ b/core/src/main/java/org/semagrow/plan/rel/ValueExprToRexConverter.java
@@ -1,0 +1,240 @@
+package org.semagrow.plan.rel;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.eclipse.rdf4j.query.algebra.*;
+import org.eclipse.rdf4j.query.algebra.BinaryValueOperator;
+import org.eclipse.rdf4j.query.algebra.UnaryValueOperator;
+import org.eclipse.rdf4j.query.algebra.ValueExpr;
+import org.eclipse.rdf4j.query.algebra.evaluation.function.datetime.*;
+import org.eclipse.rdf4j.query.algebra.evaluation.function.numeric.*;
+import org.eclipse.rdf4j.query.algebra.evaluation.function.string.*;
+import org.eclipse.rdf4j.query.algebra.evaluation.function.rdfterm.*;
+import org.semagrow.plan.rel.sparql.SparqlStdOperatorTable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by angel on 4/7/2017.
+ */
+public class ValueExprToRexConverter {
+
+    private RexBuilder rexBuilder;
+
+    Map<Class<?>, SqlOperator> ops = new HashMap<>();
+
+    public ValueExprToRexConverter(RelOptCluster cluster) {
+
+        rexBuilder = cluster.getRexBuilder();
+
+        registerOp(And.class, SparqlStdOperatorTable.AND);
+        registerOp(Or.class,  SparqlStdOperatorTable.OR);
+        registerOp(Not.class, SparqlStdOperatorTable.NOT);
+
+        registerOp(Abs.class, SparqlStdOperatorTable.ABS);
+        registerOp(Ceil.class, SparqlStdOperatorTable.CEIL);
+        registerOp(Floor.class, SparqlStdOperatorTable.FLOOR);
+        registerOp(Rand.class, SparqlStdOperatorTable.RAND);
+        registerOp(Round.class, SparqlStdOperatorTable.ROUND);
+
+        registerOp(Like.class, SparqlStdOperatorTable.LIKE);
+        registerOp(Coalesce.class, SparqlStdOperatorTable.COALESCE);
+        registerOp(Bound.class, SparqlStdOperatorTable.BOUND);
+        registerOp(IsNumeric.class, SparqlStdOperatorTable.IS_NUMERIC);
+        registerOp(IsLiteral.class, SparqlStdOperatorTable.IS_LITERAL);
+        registerOp(IsResource.class, SparqlStdOperatorTable.IS_RESOURCE);
+        registerOp(IsBNode.class, SparqlStdOperatorTable.BNODE);
+        registerOp(IsURI.class, SparqlStdOperatorTable.IS_URI);
+        registerOp(LangMatches.class, SparqlStdOperatorTable.LANG_MATCHES);
+        registerOp(Lang.class, SparqlStdOperatorTable.LANG);
+        registerOp(Label.class, SparqlStdOperatorTable.LABEL);
+        registerOp(Datatype.class, SparqlStdOperatorTable.DATATYPE);
+        registerOp(Str.class, SparqlStdOperatorTable.STR);
+        registerOp(Regex.class, SparqlStdOperatorTable.REGEX);
+
+        registerOp(StrLang.class, SparqlStdOperatorTable.STRLANG);
+        registerOp(StrDt.class, SparqlStdOperatorTable.STRDT);
+        registerOp(STRUUID.class, SparqlStdOperatorTable.STRUUID);
+        registerOp(UUID.class, SparqlStdOperatorTable.UUID);
+
+        registerOp(UpperCase.class, SparqlStdOperatorTable.UCASE);
+        registerOp(LowerCase.class, SparqlStdOperatorTable.LCASE);
+        registerOp(Substring.class, SparqlStdOperatorTable.SUBSTR);
+        registerOp(LowerCase.class, SparqlStdOperatorTable.LCASE);
+        registerOp(StrAfter.class, SparqlStdOperatorTable.STRAFTER);
+        registerOp(StrBefore.class, SparqlStdOperatorTable.STRBEFORE);
+        registerOp(StrEnds.class, SparqlStdOperatorTable.STRENDS);
+        registerOp(StrStarts.class, SparqlStdOperatorTable.STRSTARTS);
+        registerOp(StrLen.class, SparqlStdOperatorTable.STRLEN);
+        registerOp(Contains.class, SparqlStdOperatorTable.CONTAINS);
+        registerOp(Concat.class, SparqlStdOperatorTable.CONCAT);
+        registerOp(Replace.class, SparqlStdOperatorTable.REPLACE);
+        registerOp(EncodeForUri.class, SparqlStdOperatorTable.ENCODE_FOR_URI);
+
+        registerOp(If.class, SparqlStdOperatorTable.IF);
+
+        registerOp(Hours.class, SparqlStdOperatorTable.HOURS);
+        registerOp(Day.class, SparqlStdOperatorTable.DAY);
+        registerOp(Now.class, SparqlStdOperatorTable.NOW);
+        registerOp(Month.class, SparqlStdOperatorTable.MONTH);
+        registerOp(Year.class, SparqlStdOperatorTable.YEAR);
+        registerOp(Minutes.class, SparqlStdOperatorTable.MINUTES);
+        registerOp(Seconds.class, SparqlStdOperatorTable.SECONDS);
+        registerOp(Timezone.class, SparqlStdOperatorTable.TIMEZONE);
+        registerOp(Tz.class, SparqlStdOperatorTable.TZ);
+
+        registerOp(Count.class, SparqlStdOperatorTable.COUNT);
+        registerOp(Sum.class, SparqlStdOperatorTable.SUM);
+        registerOp(Avg.class, SparqlStdOperatorTable.AVG);
+        registerOp(Max.class, SparqlStdOperatorTable.MAX);
+        registerOp(Min.class, SparqlStdOperatorTable.MIN);
+        registerOp(Sample.class, SparqlStdOperatorTable.SAMPLE);
+        registerOp(GroupConcat.class, SparqlStdOperatorTable.GROUPCONCAT);
+
+        registerCompareOp(Compare.class, Compare.CompareOp.GT, SparqlStdOperatorTable.GREATER_THAN);
+        registerCompareOp(Compare.class, Compare.CompareOp.GE, SparqlStdOperatorTable.GREATER_THAN_OR_EQUAL);
+        registerCompareOp(Compare.class, Compare.CompareOp.LT, SparqlStdOperatorTable.LESS_THAN);
+        registerCompareOp(Compare.class, Compare.CompareOp.LE, SparqlStdOperatorTable.LESS_THAN_OR_EQUAL);
+        registerCompareOp(Compare.class, Compare.CompareOp.EQ, SparqlStdOperatorTable.EQUALS);
+        registerOp(SameTerm.class, SparqlStdOperatorTable.SAMETERM);
+
+        registerMathOp(MathExpr.class, MathExpr.MathOp.PLUS, SparqlStdOperatorTable.PLUS);
+        registerMathOp(MathExpr.class, MathExpr.MathOp.MINUS, SparqlStdOperatorTable.MINUS);
+        registerMathOp(MathExpr.class, MathExpr.MathOp.MULTIPLY, SparqlStdOperatorTable.MULTIPLY);
+        registerMathOp(MathExpr.class, MathExpr.MathOp.DIVIDE, SparqlStdOperatorTable.DIVIDE);
+    }
+
+
+    private void registerOp(Class<?> clazz, SqlOperator op) {
+        ops.put(clazz, op);
+    }
+
+    private void registerCompareOp(Class<?> clazz, Compare.CompareOp cmpop, SqlOperator op) {
+        //ops.put(clazz, op);
+    }
+
+    private void registerMathOp(Class<?> clazz, MathExpr.MathOp mathop,  SqlOperator op) {
+        //ops.put(clazz, op);
+    }
+
+    public RexNode convertExpr(ValueExpr e, ValueExprConverterContext ctx) {
+
+        if (e instanceof CompareAll) {
+            return convertScalar((CompareAll)e, ctx);
+        } else if (e instanceof If) {
+            return  null; //convertIf((If)e, ctx);
+        } else if (e instanceof Compare) {
+            return convertCompare((Compare) e, ctx);
+        } else if (e instanceof MathExpr) {
+            return convertMath((MathExpr) e, ctx);
+        } else if (e instanceof FunctionCall) {
+            return convertUDFCall((FunctionCall)e, ctx);
+        } else if (isCall(e)) {
+            return convertCall(e, ctx);
+        } else
+            return ctx.convertExpression(e);
+    }
+
+    private RexNode convertScalar(CompareAll e, ValueExprConverterContext ctx) {
+        RexNode q   = ctx.convertSubQuery(e.getSubQuery());
+        RexNode arg = convertExpr(e.getArg(), ctx);
+        SqlOperator op = convertCompareOp(e.getOperator());
+        return rexBuilder.makeCall(op, arg, q);
+    }
+
+    private RexNode convertCompare(Compare e, ValueExprConverterContext ctx) {
+        SqlOperator op = convertCompareOp(e.getOperator());
+        RexNode lhs = convertExpr(e.getLeftArg(), ctx);
+        RexNode rhs = convertExpr(e.getRightArg(), ctx);
+        return rexBuilder.makeCall(op, lhs, rhs);
+    }
+
+    private RexNode convertMath(MathExpr e, ValueExprConverterContext ctx) {
+        SqlOperator op = convertMathOp(e.getOperator());
+        RexNode lhs = convertExpr(e.getLeftArg(), ctx);
+        RexNode rhs = convertExpr(e.getRightArg(), ctx);
+        return rexBuilder.makeCall(op, lhs, rhs);
+    }
+
+    private RexNode convertUDFCall(FunctionCall e, ValueExprConverterContext ctx) {
+        List<RexNode> args = Lists.transform(e.getArgs(), ee -> convertExpr(ee, ctx));
+        SqlOperator op = SparqlStdOperatorTable.makeSparqlFunction(e.getURI(), args.size());
+        return rexBuilder.makeCall(op, args);
+    }
+
+    private RexNode convertCall(ValueExpr e, ValueExprConverterContext ctx) {
+        Class<?> f = functor(e);
+        SqlOperator op = ops.get(f);
+        if (op != null) {
+            List<RexNode> args = Lists.transform(args(e), a -> convertExpr(a, ctx));
+            return rexBuilder.makeCall(op, args);
+        } else
+            return null;
+    }
+
+    private SqlOperator convertCompareOp(Compare.CompareOp operator) {
+        switch (operator) {
+            case EQ : return SqlStdOperatorTable.EQUALS;
+            case GE : return SqlStdOperatorTable.GREATER_THAN_OR_EQUAL;
+            case GT : return SqlStdOperatorTable.GREATER_THAN;
+            case LE : return SqlStdOperatorTable.LESS_THAN_OR_EQUAL;
+            case LT : return SqlStdOperatorTable.LESS_THAN;
+        }
+        return null;
+    }
+
+    private SqlOperator convertMathOp(MathExpr.MathOp operator) {
+        switch (operator) {
+            case PLUS : return SqlStdOperatorTable.PLUS;
+            case MULTIPLY : return SqlStdOperatorTable.MULTIPLY;
+            case DIVIDE : return SqlStdOperatorTable.DIVIDE;
+            case MINUS : return SqlStdOperatorTable.MINUS;
+        }
+        return null;
+    }
+
+    private boolean isCall(ValueExpr e) {
+        return (e instanceof UnaryValueOperator ||
+                e instanceof BinaryValueOperator ||
+                e instanceof If ||
+                e instanceof NAryValueOperator);
+    }
+
+
+    private Class<?> functor(ValueExpr e) {
+        if (isCall(e))
+            return e.getClass();
+        else
+            return null;
+    }
+
+    private List<ValueExpr> args(ValueExpr e) {
+        ImmutableList.Builder<ValueExpr> args = ImmutableList.builder();
+        if (e instanceof UnaryValueOperator) {
+            args.add(((UnaryValueOperator) e).getArg());
+        } else if (e instanceof BinaryValueOperator) {
+            args.add(((BinaryValueOperator) e).getLeftArg());
+            args.add(((BinaryValueOperator) e).getRightArg());
+        } else if (e instanceof If) {
+            args.add(((If)e).getCondition());
+            args.add(((If)e).getResult());
+            args.add(((If)e).getAlternative());
+        } else if (e instanceof NAryValueOperator) {
+            args.addAll(((NAryValueOperator)e).getArguments());
+        }
+        return args.build();
+    }
+
+
+    interface ValueExprConverterContext {
+        RexNode convertExpression(ValueExpr e);
+        RexNode convertSubQuery(TupleExpr e);
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/logical/LogicalService.java
+++ b/core/src/main/java/org/semagrow/plan/rel/logical/LogicalService.java
@@ -1,0 +1,36 @@
+package org.semagrow.plan.rel.logical;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rex.RexNode;
+import org.semagrow.plan.rel.Service;
+
+/**
+ * Created by angel on 13/7/2017.
+ */
+public class LogicalService extends Service {
+
+
+
+    protected LogicalService(RelOptCluster cluster,
+                             RelTraitSet traits,
+                             RelNode input,
+                             RexNode ref,
+                             boolean silent) {
+        super(cluster, traits, input, ref, silent);
+    }
+
+    @Override
+    public Service copy(RelTraitSet traitSet, RelNode input, RexNode ref, boolean silent) {
+        return new LogicalService(input.getCluster(), traitSet, input, ref, silent);
+    }
+
+    static public LogicalService create(RelNode input, RexNode ref) {
+        return create(input, ref, false);
+    }
+
+    static public LogicalService create(RelNode input, RexNode ref, boolean silent) {
+        return new LogicalService(input.getCluster(), input.getTraitSet(), input, ref, silent);
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/logical/LogicalStatementScan.java
+++ b/core/src/main/java/org/semagrow/plan/rel/logical/LogicalStatementScan.java
@@ -1,0 +1,29 @@
+package org.semagrow.plan.rel.logical;
+
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rex.RexLiteral;
+import org.semagrow.plan.rel.schema.RelOptDataset;
+import org.semagrow.plan.rel.StatementScan;
+
+import java.util.List;
+
+/**
+ * Created by angel on 12/7/2017.
+ */
+public class LogicalStatementScan extends StatementScan {
+
+
+    protected LogicalStatementScan(RelOptCluster cluster, RelTraitSet traitSet, RelOptDataset dataset) {
+        super(cluster, traitSet, dataset);
+    }
+
+    static public LogicalStatementScan create(RelOptCluster cluster,
+                                 RelOptDataset dataset)
+    {
+        RelTraitSet traitSet = cluster.traitSetOf(Convention.NONE);
+
+        return new LogicalStatementScan(cluster, traitSet, dataset);
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/rules/StatementScanRule.java
+++ b/core/src/main/java/org/semagrow/plan/rel/rules/StatementScanRule.java
@@ -1,0 +1,33 @@
+package org.semagrow.plan.rel.rules;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.RelNode;
+import org.semagrow.plan.rel.StatementScan;
+import org.semagrow.plan.rel.logical.LogicalStatementScan;
+import org.semagrow.plan.rel.schema.RelOptDataset;
+
+public class StatementScanRule extends RelOptRule {
+
+    public static StatementScanRule INSTANCE = new StatementScanRule();
+
+    private StatementScanRule() {
+        super(operand(LogicalStatementScan.class, any()));
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        final StatementScan scan = call.rel(0);
+        RelNode newRel =
+                scan.getDataset().toRel(
+                        new RelOptDataset.ToRelContext() {
+                            @Override
+                            public RelOptCluster getCluster() {
+                                return scan.getCluster();
+                            }
+                        }
+                );
+        call.transformTo(newRel);
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/schema/AbstractDataset.java
+++ b/core/src/main/java/org/semagrow/plan/rel/schema/AbstractDataset.java
@@ -1,0 +1,62 @@
+package org.semagrow.plan.rel.schema;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.calcite.rel.RelDistributionTraitDef;
+import org.apache.calcite.rel.metadata.RelMdUtil;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.ImmutableBitSet;
+
+import java.util.List;
+
+public abstract class AbstractDataset implements Dataset {
+
+    @Override
+    public Statistic getStatistic() {
+        return Statistics.UNKNOWN;
+    }
+
+    @Override
+    public RelDataType getRowType(RelDataTypeFactory factory) {
+
+        final RelDataTypeFactory.FieldInfoBuilder type = factory.builder();
+
+        for (Statement.Column col : Statement.Column.values())
+            type.add(col.getName(), SqlTypeName.ANY);
+
+        return type.build();
+    }
+
+
+    static class Statistics {
+        public static Statistic UNKNOWN = new Statistic() {
+            @Override
+            public Double getStatementCount() {
+                return 100d;
+            }
+
+            @Override
+            public Double getSelectivity(RexNode node) {
+                return RelMdUtil.guessSelectivity(node);
+            }
+
+            @Override
+            public RelDistribution getDistribution() {
+                return RelDistributionTraitDef.INSTANCE.getDefault();
+            }
+
+            @Override
+            public List<DatasetDescriptor.DomainConstraint> getConstraints() {
+                return ImmutableList.of();
+            }
+
+            @Override
+            public boolean isKey(ImmutableBitSet columns) {
+                return false;
+            }
+        };
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/schema/Dataset.java
+++ b/core/src/main/java/org/semagrow/plan/rel/schema/Dataset.java
@@ -1,0 +1,62 @@
+package org.semagrow.plan.rel.schema;
+
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.util.ImmutableBitSet;
+
+import java.util.List;
+
+// a set of statements (s,p,o,g)
+
+/***
+ * A {@code Dataset} is a set of statements (i.e. quads of (s,p,o,g))
+ * that can be accessed in a particular way.
+ */
+public interface Dataset {
+
+    Statistic getStatistic();
+
+    RelDataType getRowType(RelDataTypeFactory factory);
+
+    RelNode toRel(
+            RelOptDataset.ToRelContext context,
+            RelOptDataset dataset
+    );
+
+    interface Statistic {
+
+        Double getStatementCount();
+
+        Double getSelectivity(RexNode node);
+
+        RelDistribution getDistribution();
+
+        List<DatasetDescriptor.DomainConstraint> getConstraints();
+
+        boolean isKey(ImmutableBitSet columns);
+
+    }
+
+    interface Statement {
+
+        enum Column {
+
+            SUBJECT("s"),
+            PREDICATE("p"),
+            OBJECT("o"),
+            GRAPH("g");
+
+            private String name;
+
+            Column(String columnName)  {
+                this.name = columnName;
+            }
+
+            public String getName() { return name; }
+        }
+
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/schema/DatasetDescriptor.java
+++ b/core/src/main/java/org/semagrow/plan/rel/schema/DatasetDescriptor.java
@@ -1,0 +1,34 @@
+package org.semagrow.plan.rel.schema;
+
+import org.apache.calcite.plan.RelOptPlanner;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+
+
+/**
+ * A description of a dataset, namely a set of triples of various graphs.
+ */
+public interface DatasetDescriptor {
+
+    GraphEntry getGraph();
+
+    /**
+     * Returns a segment of the dataset that satisfies a pattern.
+     * */
+    RelOptDataset getSegment(Resource subj, IRI pred, Value obj, Resource... graph);
+
+    void registerRules(RelOptPlanner planner);
+
+    interface GraphEntry {
+        String getName();
+    }
+
+    interface Factory {
+        DatasetDescriptor create(Resource config);
+    }
+
+    interface DomainConstraint {
+
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/schema/RelOptDataset.java
+++ b/core/src/main/java/org/semagrow/plan/rel/schema/RelOptDataset.java
@@ -1,0 +1,45 @@
+package org.semagrow.plan.rel.schema;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.util.ImmutableBitSet;
+
+import java.util.List;
+
+/**
+ * A filterable segment of a graph database
+ * A table of four elements (graph, subject, predicate, object)
+ * A basic nature of a fragment is characterized by the simplicity
+ * of the filters that can be applied.
+ * A projection on a basic fragment is a triple pattern.
+ * */
+public interface RelOptDataset {
+
+    DatasetDescriptor getDatasetDescriptor();
+
+    List<DatasetDescriptor.GraphEntry> getGraphs();
+
+    RelNode toRel(ToRelContext context);
+
+    List<RelCollation> getCollationList();
+
+    RelDistribution getDistribution();
+
+    List<DatasetDescriptor.DomainConstraint> getDomainConstraints();
+
+    RelDataType getRowType(RelDataTypeFactory factory);
+
+    Double getRowCount();
+
+    // distinct count.
+
+    boolean isKey(ImmutableBitSet columns);
+
+    interface ToRelContext {
+        RelOptCluster getCluster();
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/schema/RelOptDatasetImpl.java
+++ b/core/src/main/java/org/semagrow/plan/rel/schema/RelOptDatasetImpl.java
@@ -1,0 +1,76 @@
+package org.semagrow.plan.rel.schema;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.calcite.rel.RelDistributionTraitDef;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.util.ImmutableBitSet;
+
+import java.util.List;
+
+public class RelOptDatasetImpl implements RelOptDataset {
+
+    private DatasetDescriptor datasetDescriptor;
+    private Dataset dataset;
+
+    RelOptDatasetImpl(DatasetDescriptor datasetDescriptor,
+                      Dataset dataset)
+    {
+        //this.datasetDescriptor = Preconditions.checkNotNull(datasetDescriptor);
+        this.dataset = dataset;
+    }
+
+    public static RelOptDataset create(DatasetDescriptor descriptor, Dataset dataset) {
+        return new RelOptDatasetImpl(descriptor, dataset);
+    }
+
+    @Override
+    public DatasetDescriptor getDatasetDescriptor() {
+        return datasetDescriptor;
+    }
+
+    @Override
+    public List<DatasetDescriptor.GraphEntry> getGraphs() {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public RelNode toRel(ToRelContext context) {
+        return dataset.toRel(context, this);
+    }
+
+    @Override
+    public List<RelCollation> getCollationList() {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public RelDistribution getDistribution() {
+        RelDistribution dist = dataset.getStatistic().getDistribution();
+        return (dist != null) ? dist : RelDistributionTraitDef.INSTANCE.getDefault();
+    }
+
+    @Override
+    public List<DatasetDescriptor.DomainConstraint> getDomainConstraints() {
+        return dataset.getStatistic().getConstraints();
+    }
+
+    @Override
+    public RelDataType getRowType(RelDataTypeFactory factory) {
+        return dataset.getRowType(factory);
+    }
+
+    @Override
+    public Double getRowCount() {
+        return dataset.getStatistic().getStatementCount();
+    }
+
+    @Override
+    public boolean isKey(ImmutableBitSet columns) {
+        return false;
+    }
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/semagrow/Bindable.java
+++ b/core/src/main/java/org/semagrow/plan/rel/semagrow/Bindable.java
@@ -1,0 +1,24 @@
+package org.semagrow.plan.rel.semagrow;
+
+import org.reactivestreams.Publisher;
+
+import java.util.Map;
+
+public interface Bindable<T> {
+
+    Publisher<T> bind(DataContext<T> ctx);
+
+    class DataContext<T> {
+
+        /**
+         * Map that contains the name of the correlated variable and
+         * a publisher that contains none or more bindings for that variable.
+         */
+        Map<String, Publisher<T>> bindings;
+
+        static <T> DataContext<T> empty() {
+            DataContext ctx = new DataContext<T>();
+            return ctx;
+        }
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/semagrow/Prepare.java
+++ b/core/src/main/java/org/semagrow/plan/rel/semagrow/Prepare.java
@@ -1,0 +1,76 @@
+package org.semagrow.plan.rel.semagrow;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.tools.Program;
+import org.apache.calcite.tools.Programs;
+import org.eclipse.rdf4j.query.algebra.QueryRoot;
+import org.semagrow.plan.rel.TupleExprToRelConverter;
+
+/**
+ * Created by angel on 18/7/2017.
+ */
+public abstract class Prepare {
+
+    private final Convention resultConvention;
+
+    Prepare(Convention resultConvention) {
+        this.resultConvention = resultConvention;
+    }
+
+    protected RelRoot optimize(RelRoot root) {
+
+        final RelOptPlanner planner = root.rel.getCluster().getPlanner();
+
+        final RelTraitSet desiredTraits = getDesiredTraitSet(root);
+        final Program program = getProgram();
+
+        RelNode rel = program.run(planner, root.rel, desiredTraits, ImmutableList.of(), ImmutableList.of());
+
+        return root.withRel(rel);
+    }
+
+    protected Program getProgram() {
+        // FIXME : change me
+        return Programs.standard();
+    }
+
+    protected RelTraitSet getDesiredTraitSet(RelRoot root) {
+        return root.rel.getTraitSet()
+                .replace(resultConvention)
+                .replace(root.collation)
+                .simplify();
+    }
+
+    public PreparedResult prepare(QueryRoot expr) {
+
+        TupleExprToRelConverter relConverter = getTupleExprToRelConverter();
+        RelRoot root = relConverter.convertQuery(expr);
+        RelRoot rootOpt = optimize(root);
+
+        return new PreparedResultImpl(rootOpt);
+    }
+
+    protected abstract TupleExprToRelConverter getTupleExprToRelConverter();
+
+    interface PreparedResult {
+        RelNode rootRel();
+    }
+
+    static class PreparedResultImpl implements PreparedResult {
+
+        final private RelRoot root;
+
+        private PreparedResultImpl(RelRoot root) {
+            this.root = root;
+        }
+
+        @Override
+        public RelNode rootRel() { return root.rel; }
+    }
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/semagrow/ReactiveStreamsConvention.java
+++ b/core/src/main/java/org/semagrow/plan/rel/semagrow/ReactiveStreamsConvention.java
@@ -1,0 +1,12 @@
+package org.semagrow.plan.rel.semagrow;
+
+import org.apache.calcite.plan.Convention;
+
+public class ReactiveStreamsConvention extends Convention.Impl {
+
+    public static ReactiveStreamsConvention INSTANCE = new ReactiveStreamsConvention();
+
+    public ReactiveStreamsConvention() {
+        super("REACTIVE", ReactiveStreamsRel.class);
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/semagrow/ReactiveStreamsImplementor.java
+++ b/core/src/main/java/org/semagrow/plan/rel/semagrow/ReactiveStreamsImplementor.java
@@ -1,0 +1,13 @@
+package org.semagrow.plan.rel.semagrow;
+
+import org.apache.calcite.plan.RelImplementor;
+import org.reactivestreams.Publisher;
+
+public class ReactiveStreamsImplementor implements RelImplementor {
+
+    public Publisher<Object[]> implementRoot(ReactiveStreamsRel rel) {
+        Bindable<Object[]> result = rel.implement(this);
+        return result.bind(Bindable.DataContext.empty());
+    }
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/semagrow/ReactiveStreamsRel.java
+++ b/core/src/main/java/org/semagrow/plan/rel/semagrow/ReactiveStreamsRel.java
@@ -1,0 +1,10 @@
+package org.semagrow.plan.rel.semagrow;
+
+import org.apache.calcite.rel.RelNode;
+
+
+public interface ReactiveStreamsRel extends RelNode {
+
+    Bindable<Object[]> implement(ReactiveStreamsImplementor implementor);
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/semagrow/ReactiveStreamsRules.java
+++ b/core/src/main/java/org/semagrow/plan/rel/semagrow/ReactiveStreamsRules.java
@@ -1,0 +1,709 @@
+package org.semagrow.plan.rel.semagrow;
+
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import org.apache.calcite.linq4j.Ord;
+import org.apache.calcite.plan.*;
+import org.apache.calcite.rel.*;
+import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.*;
+import org.apache.calcite.rel.logical.*;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.ImmutableIntList;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+
+public class ReactiveStreamsRules {
+
+    static RelOptRule REACTIVESTREAMS_HASH_JOIN_RULE = new ReactiveStreamsHashJoinRule();
+    static RelOptRule REACTIVESTREAMS_MERGE_JOIN_RULE = new ReactiveStreamsMergeJoinRule();
+    //static RelOptRule REACTIVESTREAMS_NLJ_JOIN_RULE = new ReactiveStreamsNLJJoinRule();
+    static RelOptRule REACTIVESTREAMS_PROJECT_RULE = new ReactiveStreamsProjectRule();
+    static RelOptRule REACTIVESTREAMS_FILTER_RULE = new ReactiveStreamsFilterRule();
+    static RelOptRule REACTIVESTREAMS_AGGREGATE_RULE = new ReactiveStreamsAggregateRule();
+    static RelOptRule REACTIVESTREAMS_SORT_RULE = new ReactiveStreamsSortRule();
+    static RelOptRule REACTIVESTREAMS_INTERSECT_RULE = new ReactiveStreamsIntersectRule();
+    static RelOptRule REACTIVESTREAMS_UNION_RULE = new ReactiveStreamsUnionRule();
+    static RelOptRule REACTIVESTREAMS_VALUES_RULE = new ReactiveStreamsValuesRule();
+    static RelOptRule REACTIVESTREAMS_MINUS_RULE = new ReactiveStreamsMinusRule();
+
+    public static List<RelOptRule> RULES =
+            ImmutableList.of(
+                    REACTIVESTREAMS_HASH_JOIN_RULE,
+                    //REACTIVESTREAMS_MERGE_JOIN_RULE,
+                    REACTIVESTREAMS_PROJECT_RULE,
+                    REACTIVESTREAMS_FILTER_RULE,
+                    REACTIVESTREAMS_AGGREGATE_RULE,
+                    REACTIVESTREAMS_SORT_RULE,
+                    REACTIVESTREAMS_UNION_RULE,
+                    REACTIVESTREAMS_INTERSECT_RULE,
+                    REACTIVESTREAMS_MINUS_RULE,
+                    REACTIVESTREAMS_VALUES_RULE);
+
+    public static abstract class ReactiveStreamsConverterRule extends ConverterRule {
+
+        public ReactiveStreamsConverterRule(Class<? extends RelNode> clazz, RelTrait in, RelTrait out, String description) {
+            super(clazz, in, out, description);
+        }
+
+        public <R extends RelNode> ReactiveStreamsConverterRule(Class<R> clazz, Predicate<? super R> predicate, RelTrait in, RelTrait out, String description) {
+            super(clazz, predicate, in, out, description);
+        }
+    }
+
+    public static class ReactiveStreamsHashJoinRule extends ReactiveStreamsConverterRule {
+
+        public ReactiveStreamsHashJoinRule() {
+            super(LogicalJoin.class, Convention.NONE, ReactiveStreamsConvention.INSTANCE, "ReactiveStreamsHashJoinRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode rel) {
+            LogicalJoin join = (LogicalJoin)rel;
+
+            final RelNode left = convert(join.getLeft(), getOutTrait());
+            final RelNode right = convert(join.getRight(), getOutTrait());
+            final JoinInfo info = JoinInfo.of(left, right, join.getCondition());
+
+            if (!info.isEqui() && join.getJoinType() != JoinRelType.INNER) {
+
+                return new ReactiveStreamsThetaJoin(join.getCluster(),
+                        join.getTraitSet().replace(getOutConvention()),
+                        left,
+                        right,
+                        join.getCondition(),
+                        join.getVariablesSet(),
+                        join.getJoinType());
+            }
+
+            RelNode newRel = new ReactiveStreamsHashJoin(
+                    join.getCluster(),
+                    join.getTraitSet().replace(getOutConvention()),
+                    left,
+                    right,
+                    info.getEquiCondition(left,right,join.getCluster().getRexBuilder()),
+                    info.leftKeys,
+                    info.rightKeys,
+                    join.getVariablesSet(),
+                    join.getJoinType());
+
+            if (!info.isEqui()) {
+                newRel = new ReactiveStreamsFilter(join.getCluster(), newRel.getTraitSet(),
+                        newRel, info.getRemaining(join.getCluster().getRexBuilder()));
+            }
+            return newRel;
+        }
+    }
+
+    public static class ReactiveStreamsThetaJoin extends Join implements ReactiveStreamsRel {
+
+        protected ReactiveStreamsThetaJoin(RelOptCluster cluster,
+                                           RelTraitSet traitSet,
+                                           RelNode left,
+                                           RelNode right,
+                                           RexNode condition,
+                                           Set<CorrelationId> variablesSet,
+                                           JoinRelType joinType)
+        {
+            super(cluster, traitSet, left, right, condition, variablesSet, joinType);
+        }
+
+        @Override
+        public ReactiveStreamsThetaJoin copy(RelTraitSet traitSet,
+                                             RexNode conditionExpr,
+                                             RelNode left,
+                                             RelNode right,
+                                             JoinRelType joinType,
+                                             boolean semiJoinDone)
+        {
+            return new ReactiveStreamsThetaJoin(getCluster(),
+                    traitSet,
+                    left,
+                    right,
+                    conditionExpr,
+                    ImmutableSet.of(),
+                    joinType);
+        }
+
+        @Override
+        public Bindable<Object[]> implement(ReactiveStreamsImplementor implementor) {
+            final Bindable<Object[]> left = ((ReactiveStreamsRel) getLeft()).implement(implementor);
+            final Bindable<Object[]> right = ((ReactiveStreamsRel) getLeft()).implement(implementor);
+
+            return new Bindable<Object[]>() {
+                @Override
+                public Publisher<Object[]> bind(DataContext<Object[]> ctx) {
+                    Publisher<Object[]> leftPub = left.bind(ctx);
+                    Publisher<Object[]> rightPub =right.bind(ctx);
+                    return ReactorImpl.hashJoin(
+                            ReactorImpl.asFlux(leftPub),
+                            ReactorImpl.asFlux(rightPub),
+                            null,
+                            null,
+                            null,
+                            joinType.generatesNullsOnLeft(),
+                            joinType.generatesNullsOnRight());
+                }
+            };
+        }
+    }
+
+    public static class ReactiveStreamsHashJoin extends EquiJoin implements ReactiveStreamsRel {
+
+        protected ReactiveStreamsHashJoin(RelOptCluster cluster,
+                               RelTraitSet traitSet,
+                               RelNode left,
+                               RelNode right,
+                               RexNode condition,
+                               ImmutableIntList leftKeys,
+                               ImmutableIntList rightKeys,
+                               Set<CorrelationId> variablesSet,
+                               JoinRelType joinType)
+        {
+            super(cluster, traitSet, left, right, condition, leftKeys, rightKeys, variablesSet, joinType);
+        }
+
+        @Override
+        public ReactiveStreamsHashJoin copy(RelTraitSet traitSet, RexNode condition,
+                                            RelNode left, RelNode right, JoinRelType joinType,
+                                            boolean semiJoinDone)
+        {
+            final JoinInfo joinInfo = JoinInfo.of(left, right, condition);
+            assert joinInfo.isEqui();
+
+            return new ReactiveStreamsHashJoin(getCluster(),
+                    traitSet,
+                    left,
+                    right,
+                    condition,
+                    joinInfo.leftKeys,
+                    joinInfo.rightKeys,
+                    variablesSet,
+                    joinType);
+        }
+
+        @Override
+        public Bindable<Object[]> implement(ReactiveStreamsImplementor implementor) {
+            final Bindable<Object[]> left = ((ReactiveStreamsRel) getLeft()).implement(implementor);
+            final Bindable<Object[]> right = ((ReactiveStreamsRel) getLeft()).implement(implementor);
+
+            final Function<Object[], Object[]> outerKeySelector = TypeUtil.getAccessor(leftKeys);
+            final Function<Object[], Object[]> innerKeySelector = TypeUtil.getAccessor(rightKeys);
+            final BiFunction<Object[], Object[], Object[]> resultKeySelector = TypeUtil.getJoinSelector(rowType, getLeft().getRowType(), getRight().getRowType());
+
+            return new Bindable<Object[]>() {
+                @Override
+                public Publisher<Object[]> bind(DataContext<Object[]> ctx) {
+                    Publisher<Object[]> leftPub = left.bind(ctx);
+                    Publisher<Object[]> rightPub =right.bind(ctx);
+                    return ReactorImpl.hashJoin(
+                            ReactorImpl.asFlux(leftPub),
+                            ReactorImpl.asFlux(rightPub),
+                            outerKeySelector,
+                            innerKeySelector,
+                            resultKeySelector,
+                            joinType.generatesNullsOnLeft(),
+                            joinType.generatesNullsOnRight());
+                }
+            };
+        }
+    }
+
+    public static class ReactiveStreamsMergeJoinRule extends ReactiveStreamsConverterRule {
+
+        public ReactiveStreamsMergeJoinRule() {
+            super(LogicalJoin.class, Convention.NONE,
+                    ReactiveStreamsConvention.INSTANCE,
+                    "ReactiveStreamsMergeJoinRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode rel) {
+            LogicalJoin join = (LogicalJoin)rel;
+
+            final JoinInfo info =
+                    JoinInfo.of(join.getLeft(), join.getRight(), join.getCondition());
+
+            if (join.getJoinType() != JoinRelType.INNER) {
+                // EnumerableMergeJoin only supports inner join.
+                // (It supports non-equi join, using a post-filter; see below.)
+                return null;
+            }
+
+            if (info.pairs().size() == 0) {
+                // EnumerableMergeJoin CAN support cartesian join, but disable it for now.
+                return null;
+            }
+
+            final List<RelNode> newInputs = Lists.newArrayList();
+            final List<RelCollation> collations = Lists.newArrayList();
+
+            int offset = 0;
+            for (Ord<RelNode> ord : Ord.zip(join.getInputs())) {
+                RelTraitSet traits = ord.e.getTraitSet()
+                        .replace(getOutConvention());
+                if (!info.pairs().isEmpty()) {
+                    final List<RelFieldCollation> fieldCollations = Lists.newArrayList();
+                    for (int key : info.keys().get(ord.i)) {
+                        fieldCollations.add(
+                                new RelFieldCollation(key,
+                                        RelFieldCollation.Direction.ASCENDING,
+                                        RelFieldCollation.NullDirection.LAST));
+                    }
+                    final RelCollation collation = RelCollations.of(fieldCollations);
+                    collations.add(RelCollations.shift(collation, offset));
+                    traits = traits.replace(collation);
+                }
+                newInputs.add(convert(ord.e, traits));
+                offset += ord.e.getRowType().getFieldCount();
+            }
+            final RelNode left = newInputs.get(0);
+            final RelNode right = newInputs.get(1);
+            final RelOptCluster cluster = join.getCluster();
+
+            RelNode newRel;
+
+            RelTraitSet traits = join.getTraitSet().replace(getOutConvention());
+            if (!collations.isEmpty()) {
+                traits = traits.replace(collations);
+            }
+
+            newRel = new ReactiveStreamsMergeJoin(join.getCluster(),
+                    join.getTraitSet().replace(getOutConvention()),
+                    convert(join.getLeft(), getOutTrait()),
+                    convert(join.getRight(), getOutTrait()),
+                    join.getCondition(),
+                    join.getVariablesSet(),
+                    join.getJoinType());
+
+
+            if (!info.isEqui()) {
+                newRel = new ReactiveStreamsFilter(cluster, newRel.getTraitSet(),
+                        newRel, info.getRemaining(cluster.getRexBuilder()));
+            }
+            return newRel;
+
+        }
+    }
+
+    public static class ReactiveStreamsMergeJoin extends Join implements ReactiveStreamsRel {
+
+        protected ReactiveStreamsMergeJoin(RelOptCluster cluster,
+                                    RelTraitSet traitSet,
+                                    RelNode left,
+                                    RelNode right,
+                                    RexNode condition,
+                                    Set<CorrelationId> variablesSet,
+                                    JoinRelType joinType)
+        {
+            super(cluster, traitSet, left, right, condition, variablesSet, joinType);
+        }
+
+        @Override
+        public ReactiveStreamsMergeJoin copy(RelTraitSet traitSet,
+                                                             RexNode conditionExpr,
+                                                             RelNode left,
+                                                             RelNode right,
+                                                             JoinRelType joinType,
+                                                             boolean semiJoinDone)
+        {
+            return new ReactiveStreamsMergeJoin(getCluster(),
+                    traitSet,
+                    left,
+                    right,
+                    conditionExpr,
+                    ImmutableSet.of(),
+                    joinType);
+        }
+
+        @Override
+        public Bindable<Object[]> implement(ReactiveStreamsImplementor implementor) {
+            throw new NotImplementedException();
+        }
+    }
+
+    public static class ReactiveStreamsProjectRule extends ReactiveStreamsConverterRule {
+
+        ReactiveStreamsProjectRule() {
+            super(LogicalProject.class, Convention.NONE, ReactiveStreamsConvention.INSTANCE, "ReactiveStreamsProjectRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode rel) {
+            LogicalProject project = (LogicalProject) rel;
+            return new ReactiveStreamsRules.ReactiveStreamsProject(project.getCluster(),
+                    project.getTraitSet().replace(getOutConvention()),
+                    convert(project.getInput(), getOutTrait()),
+                    project.getProjects(),
+                    project.getRowType());
+        }
+    }
+
+    public static class ReactiveStreamsProject extends Project implements ReactiveStreamsRel {
+
+        protected ReactiveStreamsProject(RelOptCluster cluster,
+                                  RelTraitSet traits,
+                                  RelNode input,
+                                  List<? extends RexNode> projects, RelDataType rowType) {
+            super(cluster, traits, input, projects, rowType);
+        }
+
+        @Override
+        public ReactiveStreamsProject copy(RelTraitSet traitSet, RelNode input, List<RexNode> projects, RelDataType rowType) {
+            return new ReactiveStreamsProject(getCluster(), traitSet, input, projects, rowType);
+        }
+
+        @Override
+        public Bindable<Object[]> implement(ReactiveStreamsImplementor implementor) {
+            throw new NotImplementedException();
+        }
+    }
+
+    public static class ReactiveStreamsFilterRule extends ReactiveStreamsConverterRule {
+
+        ReactiveStreamsFilterRule() {
+            super(LogicalFilter.class, Convention.NONE, ReactiveStreamsConvention.INSTANCE, "ReactiveStreamsFilterRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode rel) {
+            LogicalFilter filter = (LogicalFilter)rel;
+            return new ReactiveStreamsFilter(filter.getCluster(),
+                    filter.getTraitSet().replace(getOutConvention()),
+                    convert(filter.getInput(), getOutTrait()),
+                    filter.getCondition()
+            );
+        }
+    }
+
+    public static class ReactiveStreamsFilter extends Filter implements ReactiveStreamsRel {
+
+        protected ReactiveStreamsFilter(RelOptCluster cluster, RelTraitSet traits, RelNode child, RexNode condition) {
+            super(cluster, traits, child, condition);
+        }
+
+        @Override
+        public ReactiveStreamsFilter copy(RelTraitSet traitSet, RelNode input, RexNode condition) {
+            return new ReactiveStreamsFilter(getCluster(), traitSet, input, condition);
+        }
+
+        @Override
+        public Bindable<Object[]> implement(ReactiveStreamsImplementor implementor) {
+
+            final Bindable<Object[]> input = ((ReactiveStreamsRel)getInput()).implement(implementor);
+
+            return new Bindable<Object[]>() {
+                @Override
+                public Publisher<Object[]> bind(DataContext<Object[]> ctx) {
+                    Publisher<Object[]> source = input.bind(ctx);
+                    java.util.function.Predicate<Object[]> p = new java.util.function.Predicate<Object[]>() {
+                        @Override
+                        public boolean test(Object[] objects) {
+                            return false;
+                        }
+                    };
+                    return ReactorImpl.filter(ReactorImpl.asFlux(source), p);
+                }
+            };
+        }
+    }
+
+    public static class ReactiveStreamsAggregateRule extends ReactiveStreamsConverterRule {
+
+        ReactiveStreamsAggregateRule(){
+            super(LogicalAggregate.class, Convention.NONE, ReactiveStreamsConvention.INSTANCE, "ReactiveStreamsAggregateRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode rel) {
+            LogicalAggregate aggregate = (LogicalAggregate) rel;
+            return new ReactiveStreamsAggregate(aggregate.getCluster(),
+                    aggregate.getTraitSet().replace(getOutConvention()),
+                    convert(aggregate.getInput(), getOutTrait()),
+                    aggregate.indicator,
+                    aggregate.getGroupSet(),
+                    aggregate.getGroupSets(),
+                    aggregate.getAggCallList());
+        }
+    }
+
+    public static class ReactiveStreamsAggregate extends Aggregate implements ReactiveStreamsRel {
+
+        protected ReactiveStreamsAggregate(RelOptCluster cluster,
+                                    RelTraitSet traits,
+                                    RelNode child,
+                                    boolean indicator,
+                                    ImmutableBitSet groupSet,
+                                    List<ImmutableBitSet> groupSets,
+                                    List<AggregateCall> aggCalls) {
+            super(cluster, traits, child, indicator, groupSet, groupSets, aggCalls);
+        }
+
+        @Override
+        public ReactiveStreamsAggregate copy(RelTraitSet traitSet,
+                                            RelNode input,
+                                            boolean indicator,
+                                            ImmutableBitSet groupSet,
+                                            List<ImmutableBitSet> groupSets,
+                                            List<AggregateCall> aggCalls) {
+            return new ReactiveStreamsAggregate(getCluster(), traitSet, input, indicator, groupSet, groupSets, aggCalls);
+        }
+
+        @Override
+        public Bindable<Object[]> implement(ReactiveStreamsImplementor implementor) {
+            throw new NotImplementedException();
+        }
+    }
+
+    public static class ReactiveStreamsSortRule extends ReactiveStreamsConverterRule {
+
+
+        ReactiveStreamsSortRule() {
+            super(LogicalSort.class, Convention.NONE, ReactiveStreamsConvention.INSTANCE, "ReactiveStreamsSortRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode rel) {
+            LogicalSort sort = (LogicalSort) rel;
+            return new ReactiveStreamsSort(sort.getCluster(),
+                    sort.getTraitSet().replace(getOutConvention()),
+                    convert(sort.getInput(), getOutTrait()),
+                    sort.getCollation(),
+                    sort.offset,
+                    sort.fetch);
+        }
+    }
+
+    public static class ReactiveStreamsSort extends Sort implements ReactiveStreamsRel {
+
+        public ReactiveStreamsSort(RelOptCluster cluster, RelTraitSet traits, RelNode child, RelCollation collation, RexNode offset, RexNode fetch) {
+            super(cluster, traits, child, collation, offset, fetch);
+        }
+
+        @Override
+        public ReactiveStreamsRules.ReactiveStreamsSort copy(RelTraitSet traitSet, RelNode newInput, RelCollation newCollation, RexNode offset, RexNode fetch) {
+            return new ReactiveStreamsRules.ReactiveStreamsSort(getCluster(), traitSet, newInput, newCollation, offset, fetch);
+        }
+
+        @Override
+        public Bindable<Object[]> implement(ReactiveStreamsImplementor implementor) {
+            Bindable<Object[]> input = ((ReactiveStreamsRel) getInput()).implement(implementor);
+
+            if (offset != null) {
+                int skip = RexLiteral.intValue(offset);
+            }
+
+            if (fetch != null) {
+                int limit = RexLiteral.intValue(fetch);
+            }
+
+            throw new NotImplementedException();
+        }
+    }
+
+    public static class ReactiveStreamsIntersectRule extends ReactiveStreamsConverterRule {
+
+        ReactiveStreamsIntersectRule() {
+            super(LogicalIntersect.class, Convention.NONE, ReactiveStreamsConvention.INSTANCE, "ReactiveStreamsIntersectRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode rel) {
+            LogicalIntersect intersect = (LogicalIntersect) rel;
+            return new ReactiveStreamsIntersect(
+                    intersect.getCluster(),
+                    intersect.getTraitSet().replace(getOutConvention()),
+                    convertList(intersect.getInputs(), getOutTrait()),
+                    intersect.all);
+        }
+    }
+
+    public static class ReactiveStreamsIntersect extends Intersect implements ReactiveStreamsRel {
+
+        public ReactiveStreamsIntersect(RelOptCluster cluster, RelTraitSet traits, List<RelNode> inputs, boolean all) {
+            super(cluster, traits, inputs, all);
+        }
+
+        @Override
+        public ReactiveStreamsIntersect copy(RelTraitSet traitSet, List<RelNode> inputs, boolean all) {
+            return new ReactiveStreamsIntersect(getCluster(), traitSet, inputs, all);
+        }
+
+        @Override
+        public Bindable<Object[]> implement(ReactiveStreamsImplementor implementor) {
+            List<RelNode> inputs = this.getInputs();
+            final List<Bindable<Object[]>> bindables = new ArrayList<>(inputs.size());
+
+            for (RelNode node : inputs) {
+                ReactiveStreamsRel rel = (ReactiveStreamsRel) node;
+                bindables.add(rel.implement(implementor));
+            }
+
+            return new Bindable<Object[]>() {
+                @Override
+                public Publisher<Object[]> bind(DataContext<Object[]> ctx) {
+
+                    return Flux.fromIterable(bindables)
+                            .map(x -> x.bind(ctx))
+                            .map(ReactorImpl::asFlux)
+                            .reduce(ReactorImpl::intersect)
+                            .flatMap(x -> x);
+                }
+            };
+        }
+    }
+
+    public static class ReactiveStreamsUnionRule extends ReactiveStreamsConverterRule {
+
+        ReactiveStreamsUnionRule() {
+            super(LogicalUnion.class, Convention.NONE, ReactiveStreamsConvention.INSTANCE, "ReactiveStreamsUnionRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode rel) {
+            LogicalUnion intersect = (LogicalUnion) rel;
+            return new ReactiveStreamsUnion(
+                    intersect.getCluster(),
+                    intersect.getTraitSet().replace(getOutConvention()),
+                    convertList(intersect.getInputs(), getOutTrait()),
+                    intersect.all);
+        }
+    }
+
+    public static class ReactiveStreamsUnion extends Union implements ReactiveStreamsRel {
+
+        protected ReactiveStreamsUnion(RelOptCluster cluster, RelTraitSet traits, List<RelNode> inputs, boolean all) {
+            super(cluster, traits, inputs, all);
+        }
+
+        @Override
+        public ReactiveStreamsUnion copy(RelTraitSet traitSet, List<RelNode> inputs, boolean all) {
+            return new ReactiveStreamsRules.ReactiveStreamsUnion(getCluster(), traitSet, inputs, all);
+        }
+
+        @Override
+        public Bindable<Object[]> implement(ReactiveStreamsImplementor implementor) {
+            List<RelNode> inputs = this.getInputs();
+            final List<Bindable<Object[]>> bindables = new ArrayList<>(inputs.size());
+
+            for (RelNode node : inputs) {
+                ReactiveStreamsRel rel = (ReactiveStreamsRel) node;
+                bindables.add(rel.implement(implementor));
+            }
+
+            return new Bindable<Object[]>() {
+                @Override
+                public Publisher<Object[]> bind(DataContext<Object[]> ctx) {
+
+                    return Flux.fromIterable(bindables)
+                            .map(x -> x.bind(ctx))
+                            .map(ReactorImpl::asFlux)
+                            .reduce(ReactorImpl::union)
+                            .flatMap(x -> x);
+                }
+            };
+        }
+    }
+
+    public static class ReactiveStreamsMinusRule extends ReactiveStreamsConverterRule {
+
+        ReactiveStreamsMinusRule() {
+            super(LogicalMinus.class, Convention.NONE, ReactiveStreamsConvention.INSTANCE, "ReactiveStreamsMinusRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode rel) {
+            LogicalMinus intersect = (LogicalMinus) rel;
+            return new ReactiveStreamsMinus(
+                    intersect.getCluster(),
+                    intersect.getTraitSet().replace(getOutConvention()),
+                    convertList(intersect.getInputs(), getOutTrait()),
+                    intersect.all);
+        }
+    }
+
+    public static class ReactiveStreamsMinus extends Minus implements ReactiveStreamsRel {
+
+        public ReactiveStreamsMinus(RelOptCluster cluster, RelTraitSet traits, List<RelNode> inputs, boolean all) {
+            super(cluster, traits, inputs, all);
+        }
+
+        @Override
+        public ReactiveStreamsMinus copy(RelTraitSet traitSet, List<RelNode> inputs, boolean all) {
+            return new ReactiveStreamsRules.ReactiveStreamsMinus(getCluster(),
+                    traitSet,
+                    inputs,
+                    all);
+        }
+
+        @Override
+        public Bindable<Object[]> implement(ReactiveStreamsImplementor implementor) {
+            List<RelNode> inputs = this.getInputs();
+            final List<Bindable<Object[]>> bindables = new ArrayList<>(inputs.size());
+
+            for (RelNode node : inputs) {
+                ReactiveStreamsRel rel = (ReactiveStreamsRel) node;
+                bindables.add(rel.implement(implementor));
+            }
+
+            return new Bindable<Object[]>() {
+                @Override
+                public Publisher<Object[]> bind(DataContext<Object[]> ctx) {
+
+                    return Flux.fromIterable(bindables)
+                            .map(x -> x.bind(ctx))
+                            .map(ReactorImpl::asFlux)
+                            .reduce(ReactorImpl::except)
+                            .flatMap(x -> x);
+                }
+            };
+        }
+    }
+
+    public static class ReactiveStreamsValuesRule extends ReactiveStreamsConverterRule {
+        ReactiveStreamsValuesRule() {
+            super(LogicalValues.class, Convention.NONE, ReactiveStreamsConvention.INSTANCE, "ReactiveStreamsValuesRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode rel) {
+            LogicalValues values = (LogicalValues)rel;
+            return new ReactiveStreamsValues(values.getCluster(),
+                    values.getRowType(),
+                    values.tuples,
+                    values.getTraitSet().replace(getOutConvention()));
+        }
+    }
+
+    public static class ReactiveStreamsValues extends Values implements ReactiveStreamsRel {
+
+        protected ReactiveStreamsValues(RelOptCluster cluster,
+                                 RelDataType rowType,
+                                 ImmutableList<ImmutableList<RexLiteral>> tuples,
+                                 RelTraitSet traits) {
+            super(cluster, rowType, tuples, traits);
+        }
+
+        @Override
+        public Bindable<Object[]> implement(ReactiveStreamsImplementor implementor) {
+            throw new NotImplementedException();
+        }
+    }
+
+
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/semagrow/ReactorImpl.java
+++ b/core/src/main/java/org/semagrow/plan/rel/semagrow/ReactorImpl.java
@@ -1,0 +1,100 @@
+package org.semagrow.plan.rel.semagrow;
+
+
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSource;
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public class ReactorImpl {
+
+    static <T,K,R> Flux<R> hashJoin(Flux<T> outer,
+                                Flux<T> inner,
+                                final Function<T,K> outerKeySelector,
+                                final Function<T,K> innerKeySelector,
+                                final BiFunction<T,T,R> resultSelector,
+                                final boolean generateNullsOnLeft,
+                                final boolean generateNullsOnRight) {
+
+        Mono<Map<K, Collection<T>>> lookup =  outer.collectMultimap(outerKeySelector);
+        return inner.flatMap( x ->
+                lookup.flatMap(map -> {
+                    Collection<T> tlst = map.get(innerKeySelector.apply(x));
+                    if (tlst == null) {
+                        if (generateNullsOnRight)
+                            return Flux.just(null);
+                        else
+                            return Flux.empty();
+                    } else {
+                        return Flux.fromIterable(tlst)
+                                .map(t2 -> resultSelector.apply(x, t2));
+                    }
+                }));
+    }
+
+    static <T,K,R> Flux<T> mergeJoin(Flux<T> outer,
+                                 Flux<T> inner,
+                                 final Function<T,K> outerKeySelector,
+                                 final Function<T,K> innerKeySelector,
+                                 final BiFunction<T,T,R> resultSelector,
+                                 final boolean generateNullsOnLeft,
+                                 final boolean generateNullsOnRight) {
+        return null;
+    }
+
+    static <T> Flux<T> crossProduct(Flux<T> outer,
+                                    Flux<T> inner)
+    {
+        return null;
+    }
+
+    static <T> Flux<T> filter(Flux<T> source, Predicate<T> p) {
+        return source.filter(p);
+    }
+
+    static <T> Flux<T> distinct(Flux<T> source) {
+        return source.distinct();
+    }
+
+    static <T> Flux<T> intersect(Flux<T> left, Flux<T> right) {
+        return null;
+    }
+
+    static <T> Flux<T> union(Flux<T> left, Flux<T> right) {
+        return left.mergeWith(right);
+    }
+
+    static <T> Flux<T> except(Flux<T> left, Flux<T> right) {
+        //return left(right);
+        return null;
+    }
+
+    static <T,A,R> R aggregate(Flux<T> source, A seed, BiFunction<A, T, A> func,
+                               Function<A, R> select){
+        return null;
+    }
+
+    static <T> Flux<T> skip(Flux<T> source, long offset) {
+        return source.skip(offset);
+    }
+
+    static <T> Flux<T> take(Flux<T> source, long limit) {
+        return source.take(limit);
+    }
+
+    static <T> Publisher<T> toPublisher(Flux<T> flux) {
+        return flux;
+    }
+
+    static <T> Flux<T> asFlux(Publisher<T> p) {
+        return (p instanceof Flux) ? (Flux<T>) p : FluxSource.wrap(p);
+    }
+
+    static <T> Flux<T> empty() { return Flux.empty(); }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/semagrow/SemagrowConvention.java
+++ b/core/src/main/java/org/semagrow/plan/rel/semagrow/SemagrowConvention.java
@@ -1,0 +1,12 @@
+package org.semagrow.plan.rel.semagrow;
+
+import org.apache.calcite.plan.Convention;
+
+public class SemagrowConvention extends Convention.Impl {
+
+    public static SemagrowConvention INSTANCE = new SemagrowConvention();
+
+    private SemagrowConvention() {
+        super("SEMAGROW", SemagrowRel.class);
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/semagrow/SemagrowPrepare.java
+++ b/core/src/main/java/org/semagrow/plan/rel/semagrow/SemagrowPrepare.java
@@ -1,0 +1,157 @@
+package org.semagrow.plan.rel.semagrow;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.plan.*;
+import org.apache.calcite.plan.volcano.VolcanoPlanner;
+import org.apache.calcite.rel.RelCollationTraitDef;
+import org.apache.calcite.rel.metadata.RelMetadataProvider;
+import org.apache.calcite.rel.rules.*;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.tools.Program;
+import org.apache.calcite.tools.Programs;
+import org.eclipse.rdf4j.query.algebra.QueryRoot;
+import org.semagrow.plan.rel.CatalogReader;
+import org.semagrow.plan.rel.RdfRexBuilder;
+import org.semagrow.plan.rel.TupleExprToRelConverter;
+import org.semagrow.plan.rel.type.RdfDataTypeFactory;
+
+
+import java.util.List;
+
+/**
+ * Created by angel on 18/7/2017.
+ */
+public class SemagrowPrepare {
+
+    private static final List<RelOptRule> DEFAULT_RULES =
+            ImmutableList.of(
+                    AggregateStarTableRule.INSTANCE,
+                    AggregateStarTableRule.INSTANCE2,
+                    TableScanRule.INSTANCE,
+                    JoinAssociateRule.INSTANCE,
+                    ProjectMergeRule.INSTANCE,
+                    FilterTableScanRule.INSTANCE,
+                    ProjectFilterTransposeRule.INSTANCE,
+                    FilterProjectTransposeRule.INSTANCE,
+                    FilterJoinRule.FILTER_ON_JOIN,
+                    JoinPushExpressionsRule.INSTANCE,
+                    AggregateExpandDistinctAggregatesRule.INSTANCE,
+                    AggregateReduceFunctionsRule.INSTANCE,
+                    FilterAggregateTransposeRule.INSTANCE,
+                    ProjectWindowTransposeRule.INSTANCE,
+                    JoinCommuteRule.INSTANCE,
+                    JoinPushThroughJoinRule.RIGHT,
+                    JoinPushThroughJoinRule.LEFT,
+                    SortProjectTransposeRule.INSTANCE,
+                    SortJoinTransposeRule.INSTANCE,
+                    SortUnionTransposeRule.INSTANCE);
+
+    public SemagrowPrepare() {
+    }
+
+    protected QueryParser createParser(String query) {
+        return null; //new SparqlParser(query);
+    }
+
+
+    protected RelOptCluster createCluster(RelOptPlanner planner, RexBuilder rexBuilder) {
+        return RelOptCluster.create(planner, rexBuilder);
+    }
+
+    protected RelOptPlanner createPlanner(
+            Context context,
+            org.apache.calcite.plan.Context externalContext,
+            RelOptCostFactory costFactory) {
+
+        final VolcanoPlanner planner = new VolcanoPlanner(costFactory, externalContext);
+
+        planner.addRelTraitDef(ConventionTraitDef.INSTANCE);
+
+        planner.addRelTraitDef(RelCollationTraitDef.INSTANCE);
+
+        // add abstract rules
+        planner.registerAbstractRelationalRules();
+        RelOptUtil.registerAbstractRels(planner);
+
+        registerRules(planner, DEFAULT_RULES);
+
+        // add implementation rules for convention SemagrowRel.CONVENTION
+
+        return planner;
+    }
+
+    private static void registerRules(RelOptPlanner planner, List<RelOptRule> rules) {
+        for (RelOptRule rule : rules)
+            planner.addRule(rule);
+    }
+
+
+    protected Prepare.PreparedResult prepare(Context context, String query) {
+        final RelOptPlanner planner = createPlanner(context, null, null);
+        return prepare_(context, query, planner);
+    }
+
+    protected Prepare.PreparedResult prepare_(Context context, String query, RelOptPlanner planner) {
+
+        final Convention resultConvention = getResultConvention();
+
+        final Prepare prepare = new PrepareImpl(context, planner, resultConvention);
+        final QueryParser parser = createParser(query);
+
+        QueryRoot parsed = parser.parseQuery();
+
+        return prepare.prepare(parsed);
+
+    }
+
+    protected Convention getResultConvention() { return SemagrowConvention.INSTANCE; }
+
+    interface Context {
+        // Config config();
+        // CatalogReader getCatalogReader();
+        RdfDataTypeFactory getTypeFactory();
+        RelMetadataProvider getMetadataProvider();
+    }
+
+
+    interface QueryParser {
+        String getQueryString();
+        QueryRoot parseQuery();
+    }
+
+    /*
+    class SparqlParser implements QueryParser {
+        public SparqlParser(String query) { }
+        TupleExpr parseQuery() {}
+    }*/
+
+    class PrepareImpl extends Prepare {
+
+        private final Context context;
+        private final RelOptPlanner planner;
+        private final RdfRexBuilder rexBuilder;
+
+        private PrepareImpl(
+                Context context,
+                RelOptPlanner planner,
+                Convention resultConvention) {
+            super(resultConvention);
+            this.context = context;
+            this.rexBuilder = new RdfRexBuilder(context.getTypeFactory());
+            this.planner = planner;
+        }
+
+        @Override
+        protected TupleExprToRelConverter getTupleExprToRelConverter() {
+            final RelOptCluster cluster = createCluster(planner, rexBuilder);
+            return new TupleExprToRelConverter(cluster, new CatalogReader.Impl());
+        }
+
+        @Override
+        protected Program getProgram() {
+            return Programs.standard(context.getMetadataProvider());
+        }
+    }
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/semagrow/SemagrowRel.java
+++ b/core/src/main/java/org/semagrow/plan/rel/semagrow/SemagrowRel.java
@@ -1,0 +1,12 @@
+package org.semagrow.plan.rel.semagrow;
+
+import org.apache.calcite.rel.RelNode;
+
+/**
+ * Created by angel on 13/7/2017.
+ */
+public interface SemagrowRel extends RelNode {
+
+    
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/semagrow/SemagrowRules.java
+++ b/core/src/main/java/org/semagrow/plan/rel/semagrow/SemagrowRules.java
@@ -1,0 +1,444 @@
+package org.semagrow.plan.rel.semagrow;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import org.apache.calcite.linq4j.Ord;
+import org.apache.calcite.plan.*;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.*;
+import org.apache.calcite.rel.logical.*;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.util.ImmutableBitSet;
+
+import java.util.List;
+import java.util.Set;
+
+public class SemagrowRules {
+
+    static RelOptRule SEMAGROW_JOIN_RULE = new SemagrowJoinRule();
+    static RelOptRule SEMAGROW_MERGE_JOIN_RULE = new SemagrowMergeJoinRule();
+    static RelOptRule SEMAGROW_PROJECT_RULE = new SemagrowProjectRule();
+    static RelOptRule SEMAGROW_FILTER_RULE = new SemagrowFilterRule();
+    static RelOptRule SEMAGROW_AGGREGATE_RULE = new SemagrowAggregateRule();
+    static RelOptRule SEMAGROW_SORT_RULE = new SemagrowSortRule();
+    static RelOptRule SEMAGROW_INTERSECT_RULE = new SemagrowIntersectRule();
+    static RelOptRule SEMAGROW_UNION_RULE = new SemagrowUnionRule();
+    static RelOptRule SEMAGROW_VALUES_RULE = new SemagrowValuesRule();
+    static RelOptRule SEMAGROW_MINUS_RULE = new SemagrowMinusRule();
+
+    public static List<RelOptRule> RULES =
+        ImmutableList.of(
+                SEMAGROW_JOIN_RULE,
+                //SEMAGROW_MERGE_JOIN_RULE,
+                SEMAGROW_PROJECT_RULE,
+                SEMAGROW_FILTER_RULE,
+                SEMAGROW_AGGREGATE_RULE,
+                SEMAGROW_SORT_RULE,
+                SEMAGROW_UNION_RULE,
+                SEMAGROW_INTERSECT_RULE,
+                SEMAGROW_MINUS_RULE,
+                SEMAGROW_VALUES_RULE);
+
+    public static abstract class SemagrowConverterRule extends ConverterRule {
+
+        public SemagrowConverterRule(Class<? extends RelNode> clazz, RelTrait in, RelTrait out, String description) {
+            super(clazz, in, out, description);
+        }
+
+        public <R extends RelNode> SemagrowConverterRule(Class<R> clazz, Predicate<? super R> predicate, RelTrait in, RelTrait out, String description) {
+            super(clazz, predicate, in, out, description);
+        }
+    }
+
+    public static class SemagrowJoinRule extends SemagrowConverterRule {
+
+        public SemagrowJoinRule() {
+            super(LogicalJoin.class, Convention.NONE, SemagrowConvention.INSTANCE, "SemagrowJoinRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode rel) {
+            LogicalJoin join = (LogicalJoin)rel;
+            return new SemagrowJoin(join.getCluster(),
+                    join.getTraitSet().replace(getOutConvention()),
+                    convert(join.getLeft(), getOutTrait()),
+                    convert(join.getRight(), getOutTrait()),
+                    join.getCondition(),
+                    join.getVariablesSet(),
+                    join.getJoinType());
+        }
+    }
+
+    public static class SemagrowJoin extends Join implements SemagrowRel {
+
+        protected SemagrowJoin(RelOptCluster cluster,
+                               RelTraitSet traitSet,
+                               RelNode left,
+                               RelNode right,
+                               RexNode condition,
+                               Set<CorrelationId> variablesSet,
+                               JoinRelType joinType)
+        {
+            super(cluster, traitSet, left, right, condition, variablesSet, joinType);
+        }
+
+        @Override
+        public SemagrowJoin copy(RelTraitSet traitSet, RexNode conditionExpr, RelNode left, RelNode right, JoinRelType joinType, boolean semiJoinDone) {
+            return new SemagrowJoin(getCluster(), traitSet, left, right, conditionExpr, ImmutableSet.of(), joinType);
+        }
+    }
+
+    public static class SemagrowMergeJoinRule extends SemagrowConverterRule {
+
+        public SemagrowMergeJoinRule() {
+            super(LogicalJoin.class, Convention.NONE, SemagrowConvention.INSTANCE, "SemagrowMergeJoinRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode rel) {
+            LogicalJoin join = (LogicalJoin)rel;
+
+            final JoinInfo info =
+                    JoinInfo.of(join.getLeft(), join.getRight(), join.getCondition());
+
+            if (join.getJoinType() != JoinRelType.INNER) {
+                // EnumerableMergeJoin only supports inner join.
+                // (It supports non-equi join, using a post-filter; see below.)
+                return null;
+            }
+
+            if (info.pairs().size() == 0) {
+                // EnumerableMergeJoin CAN support cartesian join, but disable it for now.
+                return null;
+            }
+
+            final List<RelNode> newInputs = Lists.newArrayList();
+            final List<RelCollation> collations = Lists.newArrayList();
+
+            int offset = 0;
+            for (Ord<RelNode> ord : Ord.zip(join.getInputs())) {
+                RelTraitSet traits = ord.e.getTraitSet()
+                        .replace(getOutConvention());
+                if (!info.pairs().isEmpty()) {
+                    final List<RelFieldCollation> fieldCollations = Lists.newArrayList();
+                    for (int key : info.keys().get(ord.i)) {
+                        fieldCollations.add(
+                                new RelFieldCollation(key,
+                                        RelFieldCollation.Direction.ASCENDING,
+                                        RelFieldCollation.NullDirection.LAST));
+                    }
+                    final RelCollation collation = RelCollations.of(fieldCollations);
+                    collations.add(RelCollations.shift(collation, offset));
+                    traits = traits.replace(collation);
+                }
+                newInputs.add(convert(ord.e, traits));
+                offset += ord.e.getRowType().getFieldCount();
+            }
+            final RelNode left = newInputs.get(0);
+            final RelNode right = newInputs.get(1);
+            final RelOptCluster cluster = join.getCluster();
+
+            RelNode newRel;
+
+            RelTraitSet traits = join.getTraitSet().replace(getOutConvention());
+            if (!collations.isEmpty()) {
+                traits = traits.replace(collations);
+            }
+
+            newRel = new SemagrowMergeJoin(join.getCluster(),
+                    join.getTraitSet().replace(getOutConvention()),
+                    convert(join.getLeft(), getOutTrait()),
+                    convert(join.getRight(), getOutTrait()),
+                    join.getCondition(),
+                    join.getVariablesSet(),
+                    join.getJoinType());
+
+
+            if (!info.isEqui()) {
+                newRel = new SemagrowFilter(cluster, newRel.getTraitSet(),
+                        newRel, info.getRemaining(cluster.getRexBuilder()));
+            }
+            return newRel;
+
+        }
+    }
+
+    public static class SemagrowMergeJoin extends Join implements SemagrowRel {
+
+        protected SemagrowMergeJoin(RelOptCluster cluster,
+                               RelTraitSet traitSet,
+                               RelNode left,
+                               RelNode right,
+                               RexNode condition,
+                               Set<CorrelationId> variablesSet,
+                               JoinRelType joinType)
+        {
+            super(cluster, traitSet, left, right, condition, variablesSet, joinType);
+        }
+
+        @Override
+        public SemagrowJoin copy(RelTraitSet traitSet, RexNode conditionExpr, RelNode left, RelNode right, JoinRelType joinType, boolean semiJoinDone) {
+            return new SemagrowJoin(getCluster(), traitSet, left, right, conditionExpr, ImmutableSet.of(), joinType);
+        }
+
+    }
+
+    public static class SemagrowProjectRule extends SemagrowConverterRule {
+
+        SemagrowProjectRule() {
+            super(LogicalProject.class, Convention.NONE, SemagrowConvention.INSTANCE, "SemagrowProjectRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode rel) {
+            LogicalProject project = (LogicalProject) rel;
+            return new SemagrowProject(project.getCluster(),
+                    project.getTraitSet().replace(getOutConvention()),
+                    convert(project.getInput(), getOutTrait()),
+                    project.getProjects(),
+                    project.getRowType());
+        }
+    }
+
+    public static class SemagrowProject extends Project implements SemagrowRel {
+
+        protected SemagrowProject(RelOptCluster cluster,
+                                  RelTraitSet traits,
+                                  RelNode input,
+                                  List<? extends RexNode> projects, RelDataType rowType) {
+            super(cluster, traits, input, projects, rowType);
+        }
+
+        @Override
+        public SemagrowProject copy(RelTraitSet traitSet, RelNode input, List<RexNode> projects, RelDataType rowType) {
+            return new SemagrowProject(getCluster(), traitSet, input, projects, rowType);
+        }
+    }
+
+    public static class SemagrowFilterRule extends SemagrowConverterRule {
+
+        SemagrowFilterRule() {
+            super(LogicalFilter.class, Convention.NONE, SemagrowConvention.INSTANCE, "SemagrowFilterRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode rel) {
+            LogicalFilter filter = (LogicalFilter)rel;
+            return new SemagrowFilter(filter.getCluster(),
+                    filter.getTraitSet().replace(getOutConvention()),
+                    convert(filter.getInput(), getOutTrait()),
+                    filter.getCondition()
+                    );
+        }
+    }
+
+    public static class SemagrowFilter extends Filter implements SemagrowRel {
+
+        protected SemagrowFilter(RelOptCluster cluster, RelTraitSet traits, RelNode child, RexNode condition) {
+            super(cluster, traits, child, condition);
+        }
+
+        @Override
+        public SemagrowFilter copy(RelTraitSet traitSet, RelNode input, RexNode condition) {
+            return new SemagrowFilter(getCluster(), traitSet, input, condition);
+        }
+    }
+
+    public static class SemagrowAggregateRule extends SemagrowConverterRule {
+
+        SemagrowAggregateRule(){
+            super(LogicalAggregate.class, Convention.NONE, SemagrowConvention.INSTANCE, "SemagrowAggregateRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode rel) {
+            LogicalAggregate aggregate = (LogicalAggregate) rel;
+            return new SemagrowAggregate(aggregate.getCluster(),
+                    aggregate.getTraitSet().replace(getOutConvention()),
+                    convert(aggregate.getInput(), getOutTrait()),
+                    aggregate.indicator,
+                    aggregate.getGroupSet(),
+                    aggregate.getGroupSets(),
+                    aggregate.getAggCallList());
+        }
+    }
+
+    public static class SemagrowAggregate extends Aggregate implements SemagrowRel {
+
+        protected SemagrowAggregate(RelOptCluster cluster,
+                                    RelTraitSet traits,
+                                    RelNode child,
+                                    boolean indicator,
+                                    ImmutableBitSet groupSet,
+                                    List<ImmutableBitSet> groupSets,
+                                    List<AggregateCall> aggCalls) {
+            super(cluster, traits, child, indicator, groupSet, groupSets, aggCalls);
+        }
+
+        @Override
+        public SemagrowAggregate copy(RelTraitSet traitSet,
+                                      RelNode input,
+                                      boolean indicator,
+                                      ImmutableBitSet groupSet,
+                                      List<ImmutableBitSet> groupSets,
+                                      List<AggregateCall> aggCalls) {
+            return new SemagrowAggregate(getCluster(), traitSet, input, indicator, groupSet, groupSets, aggCalls);
+        }
+    }
+
+    public static class SemagrowSortRule extends SemagrowConverterRule {
+
+
+        SemagrowSortRule() {
+            super(LogicalSort.class, Convention.NONE, SemagrowConvention.INSTANCE, "SemagrowSortRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode rel) {
+            LogicalSort sort = (LogicalSort) rel;
+            return new SemagrowSort(sort.getCluster(),
+                    sort.getTraitSet().replace(getOutConvention()),
+                    convert(sort.getInput(), getOutTrait()),
+                    sort.getCollation(),
+                    sort.offset,
+                    sort.fetch);
+        }
+    }
+
+    public static class SemagrowSort extends Sort implements SemagrowRel {
+
+        public SemagrowSort(RelOptCluster cluster, RelTraitSet traits, RelNode child, RelCollation collation, RexNode offset, RexNode fetch) {
+            super(cluster, traits, child, collation, offset, fetch);
+        }
+
+        @Override
+        public SemagrowSort copy(RelTraitSet traitSet, RelNode newInput, RelCollation newCollation, RexNode offset, RexNode fetch) {
+            return new SemagrowSort(getCluster(), traitSet, newInput, newCollation, offset, fetch);
+        }
+    }
+
+    public static class SemagrowIntersectRule extends SemagrowConverterRule {
+
+        SemagrowIntersectRule() {
+            super(LogicalIntersect.class, Convention.NONE, SemagrowConvention.INSTANCE, "SemagrowIntersectRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode rel) {
+            LogicalIntersect intersect = (LogicalIntersect) rel;
+            return new SemagrowIntersect(
+                    intersect.getCluster(),
+                    intersect.getTraitSet().replace(getOutConvention()),
+                    convertList(intersect.getInputs(), getOutTrait()),
+                    intersect.all);
+        }
+    }
+
+    public static class SemagrowIntersect extends Intersect implements SemagrowRel {
+
+        public SemagrowIntersect(RelOptCluster cluster, RelTraitSet traits, List<RelNode> inputs, boolean all) {
+            super(cluster, traits, inputs, all);
+        }
+
+        @Override
+        public SemagrowIntersect copy(RelTraitSet traitSet, List<RelNode> inputs, boolean all) {
+            return new SemagrowIntersect(getCluster(), traitSet, inputs, all);
+        }
+    }
+
+    public static class SemagrowUnionRule extends SemagrowConverterRule {
+
+        SemagrowUnionRule() {
+            super(LogicalUnion.class, Convention.NONE, SemagrowConvention.INSTANCE, "SemagrowUnionRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode rel) {
+            LogicalUnion intersect = (LogicalUnion) rel;
+            return new SemagrowUnion(
+                    intersect.getCluster(),
+                    intersect.getTraitSet().replace(getOutConvention()),
+                    convertList(intersect.getInputs(), getOutTrait()),
+                    intersect.all);
+        }
+    }
+
+    public static class SemagrowUnion extends Union implements SemagrowRel {
+
+        protected SemagrowUnion(RelOptCluster cluster, RelTraitSet traits, List<RelNode> inputs, boolean all) {
+            super(cluster, traits, inputs, all);
+        }
+
+        @Override
+        public SemagrowUnion copy(RelTraitSet traitSet, List<RelNode> inputs, boolean all) {
+            return new SemagrowUnion(getCluster(), traitSet, inputs, all);
+        }
+    }
+
+
+    public static class SemagrowMinusRule extends SemagrowConverterRule {
+
+        SemagrowMinusRule() {
+            super(LogicalMinus.class, Convention.NONE, SemagrowConvention.INSTANCE, "SemagrowMinusRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode rel) {
+            LogicalMinus intersect = (LogicalMinus) rel;
+            return new SemagrowMinus(
+                    intersect.getCluster(),
+                    intersect.getTraitSet().replace(getOutConvention()),
+                    convertList(intersect.getInputs(), getOutTrait()),
+                    intersect.all);
+        }
+    }
+
+    public static class SemagrowMinus extends Minus implements SemagrowRel {
+
+        public SemagrowMinus(RelOptCluster cluster, RelTraitSet traits, List<RelNode> inputs, boolean all) {
+            super(cluster, traits, inputs, all);
+        }
+
+        @Override
+        public SemagrowMinus copy(RelTraitSet traitSet, List<RelNode> inputs, boolean all) {
+            return new SemagrowMinus(getCluster(),
+                    traitSet,
+                    inputs,
+                    all);
+        }
+    }
+
+    public static class SemagrowValuesRule extends SemagrowConverterRule {
+        SemagrowValuesRule() {
+            super(LogicalValues.class, Convention.NONE, SemagrowConvention.INSTANCE, "SemagrowValuesRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode rel) {
+            LogicalValues values = (LogicalValues)rel;
+            return new SemagrowValues(values.getCluster(),
+                    values.getRowType(),
+                    values.tuples,
+                    values.getTraitSet().replace(getOutConvention()));
+        }
+    }
+
+
+    public static class SemagrowValues extends Values implements SemagrowRel {
+
+        protected SemagrowValues(RelOptCluster cluster,
+                                 RelDataType rowType,
+                                 ImmutableList<ImmutableList<RexLiteral>> tuples,
+                                 RelTraitSet traits) {
+            super(cluster, rowType, tuples, traits);
+        }
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/semagrow/TypeUtil.java
+++ b/core/src/main/java/org/semagrow/plan/rel/semagrow/TypeUtil.java
@@ -1,0 +1,67 @@
+package org.semagrow.plan.rel.semagrow;
+
+import org.apache.calcite.rel.type.RelDataType;
+
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+public class TypeUtil {
+
+    public static Function<Object[],Object[]> getAccessor(final List<Integer> fields)
+    {
+        return new Function<Object[], Object[]>() {
+            @Override
+            public Object[] apply(Object[] objects) {
+                Object[] result = new Object[fields.size()];
+                int i = 0;
+                for (Integer field : fields) {
+                    result[i] = objects[field];
+                    i++;
+                }
+                return result;
+            }
+        };
+    }
+
+
+    public static BiFunction<Object[],Object[],Object[]> getJoinSelector(final RelDataType resultType,
+                                                                         final RelDataType leftType,
+                                                                         final RelDataType rightType) {
+        return new BiFunction<Object[], Object[], Object[]>() {
+            @Override
+            public Object[] apply(Object[] left, Object[] right) {
+                Object[] result = new Object[resultType.getFieldCount()];
+
+                int j = 0;
+
+                if (left == null) {
+                    for (int i = 0; i < leftType.getFieldCount(); i++) {
+                        result[j] = null;
+                        j++;
+                    }
+                } else {
+                    for (int i = 0; i < leftType.getFieldCount(); i++) {
+                        result[j] = left[i];
+                        j++;
+                    }
+                }
+
+                if (right == null) {
+                    for (int i = 0; i < rightType.getFieldCount(); i++) {
+                        result[j] = null;
+                        j++;
+                    }
+                } else {
+                    for (int i = 0; i < rightType.getFieldCount(); i++) {
+                        result[j] = right[i];
+                        j++;
+                    }
+                }
+                return result;
+            }
+        };
+    }
+
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/ContextCollector.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/ContextCollector.java
@@ -1,0 +1,155 @@
+package org.semagrow.plan.rel.sparql;
+
+
+import org.eclipse.rdf4j.query.algebra.*;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * <p>
+ * Visitor implementation for the sesame query algebra which walks the tree and
+ * figures out the context for nodes in the algebra. The context for a node is
+ * set on the highest node in the tree. That is, everything below it shares the
+ * same context.
+ * </p>
+ *
+ * @author Blazej Bulka
+ * @since 2.7.0
+ */
+class ContextCollector extends AbstractQueryModelVisitor<Exception> {
+
+    /**
+     * Maps TupleExpr to contexts. This map contains only top-level expression
+     * elements that share the given context (i.e., all elements below share the
+     * same context) -- this is because of where contexts are being introduced
+     * into a SPARQL query -- all elements sharing the same contexts are grouped
+     * together with a "GRAPH <ctx> { ... }" clause.
+     */
+    private Map<TupleExpr, Var> mContexts = new HashMap<TupleExpr, Var>();
+
+    private ContextCollector() {
+    }
+
+    static Map<TupleExpr, Var> collectContexts(TupleExpr theTupleExpr)
+            throws Exception
+    {
+        ContextCollector aContextVisitor = new ContextCollector();
+
+        theTupleExpr.visit(aContextVisitor);
+
+        return aContextVisitor.mContexts;
+    }
+
+    public void meet(Join theJoin)
+            throws Exception
+    {
+        binaryOpMeet(theJoin, theJoin.getLeftArg(), theJoin.getRightArg());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(LeftJoin theJoin)
+            throws Exception
+    {
+        binaryOpMeet(theJoin, theJoin.getLeftArg(), theJoin.getRightArg());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Union theOp)
+            throws Exception
+    {
+        binaryOpMeet(theOp, theOp.getLeftArg(), theOp.getRightArg());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Difference theOp)
+            throws Exception
+    {
+        binaryOpMeet(theOp, theOp.getLeftArg(), theOp.getRightArg());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Intersection theOp)
+            throws Exception
+    {
+        binaryOpMeet(theOp, theOp.getLeftArg(), theOp.getRightArg());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(final Filter theFilter)
+            throws Exception
+    {
+        theFilter.getArg().visit(this);
+
+        if (mContexts.containsKey(theFilter.getArg())) {
+            Var aCtx = mContexts.get(theFilter.getArg());
+            mContexts.remove(theFilter.getArg());
+            mContexts.put(theFilter, aCtx);
+        }
+    }
+
+    private void binaryOpMeet(TupleExpr theCurrentExpr, TupleExpr theLeftExpr, TupleExpr theRightExpr)
+            throws Exception
+    {
+        theLeftExpr.visit(this);
+
+        Var aLeftCtx = mContexts.get(theLeftExpr);
+
+        theRightExpr.visit(this);
+
+        Var aRightCtx = mContexts.get(theRightExpr);
+
+        sameCtxCheck(theCurrentExpr, theLeftExpr, aLeftCtx, theRightExpr, aRightCtx);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(StatementPattern thePattern)
+            throws Exception
+    {
+        Var aCtxVar = thePattern.getContextVar();
+
+        if (aCtxVar != null) {
+            mContexts.put(thePattern, aCtxVar);
+        }
+    }
+
+    private void sameCtxCheck(TupleExpr theCurrentExpr, TupleExpr theLeftExpr, Var theLeftCtx,
+                              TupleExpr theRightExpr, Var theRightCtx)
+    {
+        if ((theLeftCtx != null) && (theRightCtx != null) && isSameCtx(theLeftCtx, theRightCtx)) {
+            mContexts.remove(theLeftExpr);
+            mContexts.remove(theRightExpr);
+            mContexts.put(theCurrentExpr, theLeftCtx);
+        }
+    }
+
+    private boolean isSameCtx(Var v1, Var v2) {
+        if ((v1 != null && v1.getValue() != null) && (v2 != null && v2.getValue() != null)) {
+            return v1.getValue().equals(v2.getValue());
+        }
+        else if ((v1 != null && v1.getName() != null) && (v2 != null && v2.getName() != null)) {
+            return v1.getName().equals(v2.getName());
+        }
+
+        return false;
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlConvention.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlConvention.java
@@ -1,0 +1,50 @@
+package org.semagrow.plan.rel.sparql;
+
+import com.google.common.base.Preconditions;
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelTrait;
+
+/**
+ * Created by angel on 13/7/2017.
+ */
+public class SparqlConvention extends Convention.Impl {
+
+    private String endpoint;
+
+    private SparqlDialect dialect;
+
+    public SparqlConvention(SparqlDialect dialect, String endpoint) {
+        super(dialect.toString() + "://" + endpoint, SparqlRel.class);
+
+        this.endpoint = Preconditions.checkNotNull(endpoint);
+        this.dialect = Preconditions.checkNotNull(dialect);
+    }
+
+    public SparqlDialect getDialect() { return dialect; }
+
+    public String getEndpoint() { return endpoint; }
+
+    public static SparqlConvention of(SparqlDialect dialect, String endpoint) {
+        return new SparqlConvention(dialect, endpoint);
+    }
+
+    @Override public boolean satisfies(RelTrait trait) {
+        if (this == trait)
+            return true;
+        else if (trait instanceof SparqlConvention) {
+            SparqlConvention that = (SparqlConvention) trait;
+            return this.getEndpoint().equals(that.getEndpoint()) &&
+                   this.getDialect().isCompatible(that.getDialect());
+        }
+        return false;
+    }
+
+    @Override public void register(RelOptPlanner planner) {
+
+        for (RelOptRule rule : SparqlRules.rules(this))
+            planner.addRule(rule);
+
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlDataset.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlDataset.java
@@ -1,0 +1,33 @@
+package org.semagrow.plan.rel.sparql;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.semagrow.plan.rel.schema.AbstractDataset;
+import org.semagrow.plan.rel.schema.RelOptDataset;
+
+
+public class SparqlDataset extends AbstractDataset {
+
+    private SparqlConvention convention;
+
+    protected SparqlDataset(SparqlConvention convention) {
+        this.convention = convention;
+    }
+
+    @Override
+    public RelNode toRel(RelOptDataset.ToRelContext context, RelOptDataset dataset) {
+        RelTraitSet traitSet = RelTraitSet.createEmpty().plus(getConvention());
+
+        return SparqlStatementPattern.create(context.getCluster(),
+                dataset,
+                traitSet,
+                getRowType(context.getCluster().getTypeFactory()),
+                ImmutableMap.of(),
+                null);
+    }
+
+    protected SparqlConvention getConvention() {
+        return convention;
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlDatasetDescriptor.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlDatasetDescriptor.java
@@ -1,0 +1,37 @@
+package org.semagrow.plan.rel.sparql;
+
+import org.apache.calcite.plan.RelOptPlanner;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.semagrow.plan.rel.schema.DatasetDescriptor;
+import org.semagrow.plan.rel.schema.RelOptDataset;
+import org.semagrow.plan.rel.schema.RelOptDatasetImpl;
+
+public class SparqlDatasetDescriptor implements DatasetDescriptor {
+
+    private final SparqlDialect dialect;
+    private final String endpoint;
+
+    private SparqlConvention convention;
+
+    public SparqlDatasetDescriptor(SparqlDialect dialect, String endpoint) {
+        this.dialect = dialect;
+        this.endpoint = endpoint;
+        this.convention = SparqlConvention.of(dialect, endpoint);
+    }
+
+    @Override
+    public GraphEntry getGraph() {
+        return null;
+    }
+
+    @Override
+    public RelOptDataset getSegment(Resource subj, IRI pred, Value obj, Resource... graph) {
+        SparqlDataset dataset = new SparqlDataset(convention);
+        return RelOptDatasetImpl.create(this, dataset);
+    }
+
+    @Override
+    public void registerRules(RelOptPlanner planner) { }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlDialect.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlDialect.java
@@ -1,0 +1,62 @@
+package org.semagrow.plan.rel.sparql;
+
+public class SparqlDialect {
+
+    private SparqlVersion version;
+    private DatabaseProduct databaseProduct;
+
+    SparqlDialect(SparqlVersion version) {
+        this.version = version;
+        this.databaseProduct = DatabaseProduct.UNKNOWN;
+    }
+
+    static public SparqlDialect create() {
+        return new SparqlDialect(SparqlVersion.SPARQL10);
+    }
+
+    public SparqlVersion getVersion() {
+        return version;
+    }
+
+    @Override
+    public String toString() { return getVersion().toString(); }
+
+    public DatabaseProduct getDatabaseProduct() { return databaseProduct; }
+
+    public boolean supportsFeature(SparqlFeature op) {
+
+        return op != null
+                && (op.isStandard()
+                && getVersion().isBackwardsCompatible(op.getRequiredSparqlVersion()));
+    }
+
+    /**
+     * Supports nested queries
+     * @return
+     */
+    public boolean supportsSubQuery() {
+        return version == SparqlVersion.SPARQL11;
+    }
+
+    /**
+     * Supports federated queries
+     * @return
+     */
+    public boolean supportsFederatedQuery() {
+        return version == SparqlVersion.SPARQL11;
+    }
+
+    public boolean isCompatible(SparqlDialect dialect) { return this == dialect; }
+
+    enum DatabaseProduct {
+        VIRTUOSO,
+        FOURSTORE,
+        UNKNOWN;
+
+        public SparqlDialect getDialect() {
+            return new SparqlDialect(SparqlVersion.SPARQL10);
+        }
+    }
+
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlFeature.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlFeature.java
@@ -1,0 +1,52 @@
+package org.semagrow.plan.rel.sparql;
+
+
+import com.google.common.collect.Maps;
+import org.apache.calcite.sql.SqlOperator;
+
+import java.util.Map;
+
+public interface SparqlFeature {
+
+    boolean isStandard();
+
+    SparqlVersion getRequiredSparqlVersion();
+
+
+    static Map<Object, SparqlFeature> features = Maps.newHashMap();
+
+    static SparqlFeature of(SqlOperator op) {
+        if (op instanceof SparqlFeature)
+            return (SparqlFeature)op;
+        else
+            return features.get(op);
+    }
+
+    static <T> T sparql10(T op) {
+        if (op != null)
+            features.put(op, StandardSparqlFeature.STD_SPARQL10);
+        return op;
+    }
+
+    static <T> T sparql11(T op) {
+        if (op != null)
+            features.put(op, StandardSparqlFeature.STD_SPARQL11);
+        return op;
+    }
+
+    enum StandardSparqlFeature implements SparqlFeature {
+
+        STD_SPARQL10(SparqlVersion.SPARQL10),
+        STD_SPARQL11(SparqlVersion.SPARQL11);
+
+        private SparqlVersion v;
+
+        StandardSparqlFeature(SparqlVersion v) {
+            this.v = v;
+        }
+
+        public SparqlVersion getRequiredSparqlVersion() { return v; }
+        public boolean isStandard() { return true; }
+    }
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlFunction.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlFunction.java
@@ -1,0 +1,53 @@
+package org.semagrow.plan.rel.sparql;
+
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.SqlOperandTypeChecker;
+import org.apache.calcite.sql.type.SqlOperandTypeInference;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+
+/**
+ * A non-standard SPARQL FunctionCall using functor name a IRI.
+ * */
+public class SparqlFunction extends SqlFunction implements SparqlFeature {
+
+    private SparqlVersion requiredVersion;
+
+    public SparqlFunction(String name,
+                          SqlReturnTypeInference returnTypeInference,
+                          SqlOperandTypeInference operandTypeInference,
+                          SqlOperandTypeChecker operandTypeChecker,
+                          SparqlVersion requiredVersion)
+    {
+        this(name,
+            returnTypeInference,
+            operandTypeInference,
+            operandTypeChecker,
+            SqlFunctionCategory.USER_DEFINED_FUNCTION,
+            requiredVersion);
+    }
+
+    public SparqlFunction(String name,
+                          SqlReturnTypeInference returnTypeInference,
+                          SqlOperandTypeInference operandTypeInference,
+                          SqlOperandTypeChecker operandTypeChecker,
+                          SqlFunctionCategory sqlFunctionCategory,
+                          SparqlVersion requiredVersion)
+    {
+        super(name,
+                SqlKind.OTHER_FUNCTION,
+                returnTypeInference,
+                operandTypeInference,
+                operandTypeChecker,
+                sqlFunctionCategory);
+
+        this.requiredVersion = requiredVersion;
+    }
+
+
+    public boolean isStandard() { return true; }
+
+    public SparqlVersion getRequiredSparqlVersion() { return this.requiredVersion; }
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlImplementor.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlImplementor.java
@@ -1,0 +1,28 @@
+package org.semagrow.plan.rel.sparql;
+
+import org.apache.calcite.plan.RelImplementor;
+import org.apache.calcite.rel.RelNode;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+
+/**
+ * Created by angel on 15/7/2017.
+ */
+public interface SparqlImplementor extends RelImplementor {
+
+    Result implement(RelNode node);
+
+
+    interface Result {
+
+        /*
+        TupleExpr root;
+
+        TupleExpr getExpr()
+        */
+
+        String asQueryString();
+
+        TupleExpr asTupleExpr();
+
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlImplementorImpl.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlImplementorImpl.java
@@ -1,0 +1,61 @@
+package org.semagrow.plan.rel.sparql;
+
+import com.google.common.base.Preconditions;
+import org.apache.calcite.rel.RelNode;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.parser.ParsedTupleQuery;
+import org.eclipse.rdf4j.queryrender.QueryRenderer;
+import org.semagrow.plan.rel.RelToTupleExprConverter;
+
+public class SparqlImplementorImpl
+        extends RelToTupleExprConverter
+        implements SparqlImplementor {
+
+    @Override
+    public Result implement(RelNode node) {
+        TupleExpr root = dispatch(node);
+        return result(root);
+    }
+
+    public TupleExpr visit(SparqlStatementPattern pattern) {
+        return null;
+    }
+
+
+    @Override public TupleExpr visit(RelNode rel) {
+        if (rel instanceof SparqlRel)
+            return ((SparqlRel)rel).implement(this).asTupleExpr();
+        else
+            return super.visit(rel);
+    }
+
+
+    protected Result result(TupleExpr e) {
+        return new ResultImpl(e);
+    }
+
+    class ResultImpl implements Result {
+
+        private TupleExpr root;
+
+        ResultImpl(TupleExpr root) {
+            this.root = Preconditions.checkNotNull(root);
+        }
+
+
+        @Override
+        public String asQueryString() {
+            final QueryRenderer renderer = new SparqlQueryRenderer();
+            try {
+                return renderer.render(new ParsedTupleQuery(root));
+            } catch (Exception e) {
+                throw new AssertionError();
+            }
+        }
+
+        public TupleExpr asTupleExpr() {
+            return root;
+        }
+    }
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlQueryRenderer.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlQueryRenderer.java
@@ -1,0 +1,199 @@
+package org.semagrow.plan.rel.sparql;
+
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.algebra.OrderElem;
+import org.eclipse.rdf4j.query.algebra.ProjectionElem;
+import org.eclipse.rdf4j.query.algebra.ProjectionElemList;
+import org.eclipse.rdf4j.query.parser.ParsedBooleanQuery;
+import org.eclipse.rdf4j.query.parser.ParsedGraphQuery;
+import org.eclipse.rdf4j.query.parser.ParsedQuery;
+import org.eclipse.rdf4j.query.parser.ParsedTupleQuery;
+import org.eclipse.rdf4j.queryrender.QueryRenderer;
+
+/**
+ * <p>
+ * Implementation of the {@link QueryRenderer} interface which renders queries
+ * into the SPARQL syntax.
+ * </p>
+ *
+ * @author Michael Grove
+ * @since 2.7.0
+ */
+public class SparqlQueryRenderer implements QueryRenderer {
+
+    /**
+     * The query renderer
+     */
+    private SparqlTupleExprRenderer mRenderer = new SparqlTupleExprRenderer();
+
+    /**
+     * @inheritDoc
+     */
+    public QueryLanguage getLanguage() {
+        return QueryLanguage.SPARQL;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public String render(final ParsedQuery theQuery)
+            throws Exception
+    {
+        mRenderer.reset();
+
+        StringBuffer aBody = new StringBuffer(mRenderer.render(theQuery.getTupleExpr()));
+
+        boolean aFirst = true;
+
+        StringBuffer aQuery = new StringBuffer();
+
+        if (theQuery instanceof ParsedTupleQuery) {
+            aQuery.append("select ");
+        }
+        else if (theQuery instanceof ParsedBooleanQuery) {
+            aQuery.append("ask\n");
+        }
+        else {
+            aQuery.append("construct ");
+        }
+
+        if (mRenderer.isDistinct()) {
+            aQuery.append("distinct ");
+        }
+
+        if (mRenderer.isReduced() && theQuery instanceof ParsedTupleQuery) {
+            aQuery.append("reduced ");
+        }
+
+        if (!mRenderer.getProjection().isEmpty() && !(theQuery instanceof ParsedBooleanQuery)) {
+
+            aFirst = true;
+
+            if (!(theQuery instanceof ParsedTupleQuery)) {
+                aQuery.append(" {\n");
+            }
+
+            for (ProjectionElemList aList : mRenderer.getProjection()) {
+                if (SparqlTupleExprRenderer.isSPOElemList(aList)) {
+                    if (!aFirst) {
+                        aQuery.append("\n");
+                    }
+                    else {
+                        aFirst = false;
+                    }
+
+                    aQuery.append("  ").append(mRenderer.renderPattern(mRenderer.toStatementPattern(aList)));
+                }
+                else {
+                    for (ProjectionElem aElem : aList.getElements()) {
+                        if (!aFirst) {
+                            aQuery.append(" ");
+                        }
+                        else {
+                            aFirst = false;
+                        }
+
+                        aQuery.append("?" + aElem.getSourceName());
+
+                        // SPARQL does not support this, its an artifact of copy and
+                        // paste from the serql stuff
+                        // aQuery.append(mRenderer.getExtensions().containsKey(aElem.getSourceName())
+                        // ?
+                        // mRenderer.renderValueExpr(mRenderer.getExtensions().get(aElem.getSourceName()))
+                        // : "?"+aElem.getSourceName());
+                        //
+                        // if (!aElem.getSourceName().equals(aElem.getTargetName()) ||
+                        // (mRenderer.getExtensions().containsKey(aElem.getTargetName())
+                        // &&
+                        // !mRenderer.getExtensions().containsKey(aElem.getSourceName())))
+                        // {
+                        // aQuery.append(" as ").append(mRenderer.getExtensions().containsKey(aElem.getTargetName())
+                        // ?
+                        // mRenderer.renderValueExpr(mRenderer.getExtensions().get(aElem.getTargetName()))
+                        // : aElem.getTargetName());
+                        // }
+                    }
+                }
+            }
+
+            if (!(theQuery instanceof ParsedTupleQuery)) {
+                aQuery.append("}");
+            }
+
+            aQuery.append("\n");
+        }
+        else if (mRenderer.getProjection().isEmpty()) {
+            if (theQuery instanceof ParsedGraphQuery) {
+                aQuery.append("{ }\n");
+            }
+            else if (theQuery instanceof ParsedTupleQuery) {
+                aQuery.append("*\n");
+            }
+        }
+
+        if (theQuery.getDataset() != null) {
+            for (IRI aURI : theQuery.getDataset().getDefaultGraphs()) {
+                aQuery.append("from <").append(aURI).append(">\n");
+            }
+
+            for (IRI aURI : theQuery.getDataset().getNamedGraphs()) {
+                aQuery.append("from named <").append(aURI).append(">\n");
+            }
+        }
+
+        if (aBody.length() > 0) {
+
+            // this removes any superflous trailing commas, i think this is just an
+            // artifact of this code's history
+            // from initially being a serql renderer. i'll leave it for now, but i
+            // think this is to be removed.
+            // test cases to prove these things work would be lovely.
+            if (aBody.toString().trim().lastIndexOf(",") == aBody.length() - 1) {
+                aBody.setCharAt(aBody.lastIndexOf(","), ' ');
+            }
+
+            if (!(theQuery instanceof ParsedBooleanQuery)) {
+                aQuery.append("where ");
+            }
+
+            aQuery.append("{\n");
+            aQuery.append(aBody);
+            aQuery.append("}");
+        }
+
+        if (!mRenderer.getOrdering().isEmpty()) {
+            aQuery.append("\norder by ");
+
+            aFirst = true;
+            for (OrderElem aOrder : mRenderer.getOrdering()) {
+                if (!aFirst) {
+                    aQuery.append(" ");
+                }
+                else {
+                    aFirst = false;
+                }
+
+                if (aOrder.isAscending()) {
+                    aQuery.append(mRenderer.renderValueExpr(aOrder.getExpr()));
+                }
+                else {
+                    aQuery.append("desc(");
+                    aQuery.append(mRenderer.renderValueExpr(aOrder.getExpr()));
+                    aQuery.append(")");
+                }
+            }
+        }
+
+        if (mRenderer.getLimit() != -1 && !(theQuery instanceof ParsedBooleanQuery)) {
+            aQuery.append("\nlimit ").append(mRenderer.getLimit());
+        }
+
+        if (mRenderer.getOffset() != -1) {
+            aQuery.append("\noffset ").append(mRenderer.getOffset());
+        }
+
+        return aQuery.toString();
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlQueryStringUtil.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlQueryStringUtil.java
@@ -1,0 +1,594 @@
+package org.semagrow.plan.rel.sparql;
+
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.util.Literals;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.*;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
+import org.eclipse.rdf4j.query.parser.ParsedBooleanQuery;
+import org.eclipse.rdf4j.query.parser.ParsedTupleQuery;
+import org.eclipse.rdf4j.query.parser.sparql.SPARQLUtil;
+import org.eclipse.rdf4j.queryrender.RenderUtils;
+import org.semagrow.model.PlainLiteral;
+import org.semagrow.plan.Plan;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+
+/**
+ * Various static functions for query handling.
+ *
+ * @author Angelos Charalambidis
+ * @author Antonis Troumpoukis
+ */
+
+public class SparqlQueryStringUtil {
+
+
+    private static boolean rowIdOpt = false;
+
+    private static String INDEX_BINDING_NAME = "__id";
+
+
+
+    public static String toSPARQL(Value theValue) {
+        StringBuilder aBuffer = toSPARQL(theValue, new StringBuilder());
+        return aBuffer.toString();
+    }
+
+    public static StringBuilder toSPARQL(Value value, StringBuilder builder) {
+        if(value instanceof IRI) {
+            IRI aLit = (IRI)value;
+            builder.append("<").append(aLit.toString()).append(">");
+        } else if(value instanceof BNode) {
+            builder.append("_:").append(((BNode)value).getID());
+        } else if(value instanceof Literal) {
+            Literal aLit1 = (Literal)value;
+            builder.append("\"\"\"").append(RenderUtils.escape(aLit1.getLabel())).append("\"\"\"");
+            if(Literals.isLanguageLiteral(aLit1)) {
+                builder.append("@").append(aLit1.getLanguage());
+            } else if (value instanceof PlainLiteral) {
+                // do not print type
+            } else {
+                builder.append("^^<").append(aLit1.getDatatype().toString()).append(">");
+            }
+        }
+
+        return builder;
+    }
+
+    /**
+     * Computes the VALUES clause for the set of relevant input bindings. The
+     * VALUES clause is attached to a subquery for block-nested-loop evaluation.
+     * Implementation note: we use a special binding to mark the rowIndex of the
+     * input binding.
+     *
+     * @param bindings
+     * @param relevantBindingNames
+     * @return a string with the VALUES clause for the given set of relevant
+     *         input bindings
+     * @throws QueryEvaluationException
+     */
+    private static String buildVALUESClause(List<BindingSet> bindings, Set<String> relevantBindingNames)
+            throws QueryEvaluationException
+    {
+
+        if (relevantBindingNames.isEmpty())
+            return "";
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(" VALUES (");
+
+        if (rowIdOpt)
+            sb.append(" ?"+ INDEX_BINDING_NAME);
+
+        for (String bName : relevantBindingNames) {
+            sb.append(" ?").append(bName);
+        }
+
+        sb.append(") { ");
+
+        int rowIdx = 0;
+        for (BindingSet b : bindings) {
+            sb.append(" (");
+
+            if (rowIdOpt) {
+                sb.append("\"").append(rowIdx++).append("\" "); // identification of the row for post processing
+            }
+
+            for (String bName : relevantBindingNames) {
+                appendValueAsString(sb, b.getValue(bName)).append(" ");
+            }
+            sb.append(")");
+        }
+
+        sb.append(" }");
+        return sb.toString();
+    }
+
+    /**
+     * Construct a SPARQL query string for the provided tuple exprossion.
+     * If the projection is empty or null, build an ASK query, otherwise build a SELECT query.
+     *
+     * @param expr
+     * @param projection
+     * @return The corresponding SPARQL query string
+     * @throws Exception
+     */
+
+
+    public static String buildSPARQLQuery(TupleExpr expr, Collection<String> projection)
+            throws Exception
+    {
+        if (projection != null && projection.isEmpty())
+            return buildAskSPARQLQuery(expr);
+        else
+            return buildSelectSPARQLQuery(expr, projection);
+    }
+
+
+    private static String buildSelectSPARQLQuery(TupleExpr expr, Collection<String> projection)
+            throws Exception
+    {
+        TupleExpr body = expr.clone();
+
+        if (projection != null) {
+            Projection proj = new Projection();
+            ProjectionElemList elemList = new ProjectionElemList();
+
+            for (String var : projection)
+                elemList.addElement(new ProjectionElem(var));
+
+            proj.setProjectionElemList(elemList);
+
+            proj.setArg(body);
+            body = proj;
+        }
+
+        ParsedTupleQuery query = new ParsedTupleQuery(body);
+
+        String queryString = new SparqlQueryRenderer().render(new ParsedTupleQuery(expr));
+        queryString = updateFunctionCallsSELECT(expr, queryString, computeVars(expr));
+
+        return queryString;
+    }
+
+    private static String buildAskSPARQLQuery(TupleExpr expr) throws Exception
+    {
+        ParsedBooleanQuery query = new ParsedBooleanQuery(expr);
+        return new SparqlQueryRenderer().render(query);
+    }
+
+    /**
+     * Construct a bind join subquery for the provided tuple exprossion and a set of relevant input bindings,
+     * using the SPARQL 1.1 VALUES operator.
+     *
+     * @param expr
+     * @param bindings
+     * @param relevantBindingNames
+     * @return The corresponding SPARQL query string
+     * @throws Exception
+     */
+
+    public static String buildSPARQLQueryVALUES(TupleExpr expr,
+                                         List<BindingSet> bindings,
+                                         Set<String> relevantBindingNames)
+            throws Exception
+    {
+        Set<String> freeVars = computeVars(expr);
+
+        if (rowIdOpt)
+            freeVars.add(INDEX_BINDING_NAME);
+
+        //freeVars.removeAll(relevantBindingNames);
+
+        return buildSPARQLQuery(expr,freeVars) + buildVALUESClause(bindings,relevantBindingNames);
+    }
+
+    /**
+     * Construct a bind join subquery for the provided tuple exprossion and a set of relevant input bindings,
+     * using the UNION operator.
+     *
+     * @param expr
+     * @param bindings
+     * @param relevantBindingNames
+     * @return The corresponding SPARQL query string
+     * @throws Exception
+     */
+
+    public static String buildSPARQLQueryUNION(TupleExpr expr,
+                                           List<BindingSet> bindings,
+                                           Collection<String> relevantBindingNames)
+            throws Exception
+    {
+
+        Set<String> freeVars = computeVars(expr);
+        freeVars.removeAll(relevantBindingNames);
+
+        if (freeVars.isEmpty()) {
+            return buildSPARQLQueryUNIONFILTER(expr, bindings, relevantBindingNames);
+        }
+
+        String query = new SparqlQueryRenderer().render(new ParsedTupleQuery(expr));
+        query = updateFunctionCallsSELECT(expr, query, freeVars);
+        freeVars.addAll(additionalBindingNames(expr));
+        String where = query.substring(query.indexOf('{'));
+        StringBuilder sb = new StringBuilder();
+
+        int i = 1;
+        boolean flag = false;
+        
+        for (BindingSet b : bindings) {
+            if (flag) {
+                sb.append(" UNION ");
+            }
+            flag = true;
+            String tmpStr = where;
+            for (String name : relevantBindingNames) {
+                String pattern = "[\\?\\$]" + name + "(?=\\W)";
+                StringBuilder val = new StringBuilder();
+                appendValueAsString(val, b.getValue(name));
+                String replacement = val.toString();
+                tmpStr = tmpStr.replaceAll(pattern, Matcher.quoteReplacement(replacement));
+            }
+            for (String name : freeVars) {
+                String pattern = "[\\?\\$]" + name + "(?=\\W)";
+                String replacement = "?" + name + "_" + i;
+                tmpStr = tmpStr.replaceAll(pattern, Matcher.quoteReplacement(replacement));
+            }
+            sb.append(tmpStr);
+            i++;
+        }
+        sb.append(" }");
+        String pr = "SELECT ";
+        for (int j=1; j<i; j++) {
+            for (String name : freeVars) {
+                pr = pr + "?" + name + "_" + j + " ";
+            }
+        }
+        pr = pr + "\nWHERE { ";
+        return (pr + sb.toString());
+    }
+
+    private static String buildSPARQLQueryUNIONFILTER(TupleExpr expr,
+                                                      List<BindingSet> bindings,
+                                                      Collection<String> relevantBindingNames)
+            throws Exception
+    {
+        String query = new SparqlQueryRenderer().render(new ParsedTupleQuery(expr));
+        query = updateFunctionCallsBIND(expr, query); // not tested
+        relevantBindingNames.addAll(additionalBindingNames(expr)); // not tested
+        String where = query.substring(query.indexOf('{'));
+        StringBuilder sb = new StringBuilder();
+
+        int i = 1;
+        boolean flag1 = false;
+        for (BindingSet b : bindings) {
+            if (flag1) {
+                sb.append(" UNION ");
+            }
+            flag1 = true;
+            String tmpStr = where;
+            for (String name : relevantBindingNames) {
+                String pattern = "[\\?\\$]" + name + "(?=\\W)";
+                String replacement = "?" + name + "_" + i;
+                tmpStr = tmpStr.replaceAll(pattern, Matcher.quoteReplacement(replacement));
+            }
+            tmpStr = tmpStr.substring(0,tmpStr.lastIndexOf('}'));
+            sb.append(tmpStr);
+            sb.append(" FILTER (");
+            boolean flag = false;
+            for (String name : relevantBindingNames) {
+                if (flag) {
+                    sb.append(" and ");
+                }
+                flag = true;
+                sb.append("?"+name + "_" + i +"=");
+                appendValueAsString(sb, b.getValue(name));
+            }
+            sb.append(") }");
+            i++;
+        }
+        sb.append(" }");
+        String pr = "SELECT ";
+        for (int j=1; j<i; j++) {
+            for (String name : relevantBindingNames) {
+                pr = pr + "?" + name + "_" + j + " ";
+            }
+        }
+        pr = pr + "\nWHERE { ";
+        return (pr + sb.toString());
+    }
+
+    private static String updateFunctionCallsBIND(TupleExpr expr, String query) {
+
+        String newString = query;
+        StringBuilder builder = new StringBuilder();
+
+        if (expr instanceof Plan) {
+            TupleExpr e = ((Plan) expr).getArg();
+            if (e instanceof Extension) {
+                for (ExtensionElem elem : ((Extension) e).getElements()) {
+                    ValueExpr f = elem.getExpr();
+                    if (f instanceof FunctionCall) {
+
+                        builder.append("  BIND(<" + ((FunctionCall) f).getURI() + ">(");
+                        boolean flag = false;
+                        for (ValueExpr arg : ((FunctionCall) f).getArgs()) {
+
+                            if (flag) {
+                                builder.append(", ");
+                            }
+                            if (arg instanceof Var) {
+                                builder.append("?" + ((Var) arg).getName());
+                            }
+                            if (arg instanceof ValueConstant) {
+                                appendValueAsString(builder, ((ValueConstant) arg).getValue());
+                            }
+                            flag = true;
+                        }
+                        builder.append(") as ?" + elem.getName() + ") .\n");
+                    }
+                }
+            }
+        }
+
+        newString = newString.replace("}", builder.toString() + "}");
+        return newString;
+    }
+
+    private static String updateFunctionCallsSELECT(TupleExpr expr, String query, Set<String> freeVars) {
+
+        Boolean extensionFlag = false;
+
+        String newString = query;
+        StringBuilder builder = new StringBuilder();
+
+        builder.append("\nSELECT ");
+        for (String var : freeVars) {
+            builder.append("?"+var+" ");
+        }
+
+        if (expr instanceof Plan) {
+            TupleExpr e = ((Plan) expr).getArg();
+            if (e instanceof Extension) {
+                extensionFlag = true;
+                for (ExtensionElem elem : ((Extension) e).getElements()) {
+                    ValueExpr f = elem.getExpr();
+                    if (f instanceof FunctionCall) {
+
+                        builder.append("(<" + ((FunctionCall) f).getURI() + ">(");
+                        boolean flag = false;
+                        for (ValueExpr arg : ((FunctionCall) f).getArgs()) {
+
+                            if (flag) {
+                                builder.append(", ");
+                            }
+                            if (arg instanceof Var) {
+                                builder.append("?" + ((Var) arg).getName());
+                            }
+                            if (arg instanceof ValueConstant) {
+                                appendValueAsString(builder, ((ValueConstant) arg).getValue());
+                            }
+                            flag = true;
+                        }
+                        builder.append(") as ?" + elem.getName() + ")");
+                    }
+                }
+            }
+        }
+        if (extensionFlag) {
+            builder.append("\nWHERE {");
+            newString = newString.replace("{", "{" + builder.toString());
+            newString = newString + "\n}";
+        }
+        return newString;
+    }
+
+    private static Set<String> additionalBindingNames(TupleExpr expr) {
+
+        Set<String> set = new HashSet<>();
+
+        if (expr instanceof Plan) {
+            TupleExpr e = ((Plan) expr).getArg();
+            if (e instanceof Extension) {
+                for (ExtensionElem elem : ((Extension) e).getElements()) {
+                    ValueExpr f = elem.getExpr();
+                    if (f instanceof FunctionCall) {
+                        set.add(elem.getName());
+                    }
+                }
+            }
+        }
+        return set;
+    }
+
+    public static String tupleExpr2Str(TupleExpr expr) {
+        try {
+            return new SparqlQueryRenderer().render(new ParsedTupleQuery(expr)).substring(15).replace('\n',' ');
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "";
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////
+    ////////////////////////////////////////////////////////////////////////////////////
+
+
+    private static StringBuilder appendValueAsString(StringBuilder sb, Value value)
+    {
+        return sb.append(getReplacement(value));
+        /*
+        // TODO check if there is some convenient method in Sesame!
+
+        if (value == null)
+            return sb.append("UNDEF"); // see grammar for BINDINGs def
+
+        else if (value instanceof IRI)
+            return appendURI(sb, (IRI)value);
+
+        else if (value instanceof Literal)
+            return appendLiteral(sb, (Literal)value);
+
+        // XXX check for other types ? BNode ?
+        throw new RuntimeException("Type not supported: " + value.getClass().getCanonicalName());
+        */
+    }
+
+
+    /**
+     * Append the uri to the stringbuilder, i.e. <uri.stringValue>.
+     *
+     * @param sb
+     * @param uri
+     * @return the StringBuilder, for convenience
+     */
+    private static StringBuilder appendURI(StringBuilder sb, IRI uri)
+    {
+        sb.append("<").append(uri.stringValue()).append(">");
+        return sb;
+    }
+
+    /**
+     * Append the literal to the stringbuilder: "myLiteral"^^<dataType>
+     *
+     * @param sb
+     * @param lit
+     * @return the StringBuilder, for convenience
+     */
+    private static StringBuilder appendLiteral(StringBuilder sb, Literal lit)
+    {
+        sb.append('"');
+        sb.append(lit.getLabel().replace("\"", "\\\""));
+        sb.append('"');
+
+        //if (Literals.isLanguageLiteral(lit)) {
+        //    sb.append('@');
+        //    sb.append(lit.getLanguage());
+        // }
+        //else {
+        if (lit.getDatatype() != null) {
+            sb.append("^^<");
+            sb.append(lit.getDatatype().stringValue());
+            sb.append('>');
+        }
+        //}
+        return sb;
+    }
+
+    /**
+     * Compute the variable names occurring in the service expression using tree
+     * traversal, since these are necessary for building the SPARQL query.
+     *
+     * @return the set of variable names in the given service expression
+     */
+    private static Set<String> computeVars(TupleExpr serviceExpression) {
+        final Set<String> res = new HashSet<String>();
+        serviceExpression.visit(new AbstractQueryModelVisitor<RuntimeException>() {
+
+            @Override
+            public void meet(Var node)
+                    throws RuntimeException
+            {
+                // take only real vars, i.e. ignore blank nodes
+                if (!node.hasValue() && !node.isAnonymous())
+                    res.add(node.getName());
+            }
+            // TODO maybe stop tree traversal in nested SERVICE?
+            // TODO special case handling for BIND
+        });
+        return res;
+    }
+
+
+
+    // TODO maybe add BASE declaration here as well?
+
+    /**
+     * Retrieve a modified queryString into which all bindings of the given
+     * argument are replaced.
+     *
+     * @param queryString
+     * @param bindings
+     * @return the modified queryString
+     */
+    public static String getQueryString(String queryString, BindingSet bindings) {
+        if (bindings.size() == 0) {
+            return queryString;
+        }
+
+        String qry = queryString;
+        int b = qry.indexOf('{');
+        String select = qry.substring(0, b);
+        String where = qry.substring(b);
+        for (String name : bindings.getBindingNames()) {
+            String replacement = getReplacement(bindings.getValue(name));
+            if (replacement != null) {
+                String pattern = "[\\?\\$]" + name + "(?=\\W)";
+                select = select.replaceAll(pattern, "(" + Matcher.quoteReplacement(replacement) + " as ?" + name
+                        + ")");
+
+                // we use Matcher.quoteReplacement to make sure things like newlines
+                // in literal values
+                // are preserved
+                where = where.replaceAll(pattern, Matcher.quoteReplacement(replacement));
+            }
+        }
+        return select + where;
+    }
+
+    private static String getReplacement(Value value) {
+        StringBuilder sb = new StringBuilder();
+        if (value instanceof IRI) {
+            return appendValue(sb, (IRI)value).toString();
+        }
+        else if (value instanceof PlainLiteral) {
+            return appendValue(sb, (PlainLiteral)value).toString();
+        }
+        else if (value instanceof Literal) {
+            return appendValue(sb, (Literal)value).toString();
+        }
+        else {
+            throw new IllegalArgumentException("BNode references not supported by SPARQL end-points");
+        }
+    }
+
+    private static StringBuilder appendValue(StringBuilder sb, IRI uri) {
+        sb.append("<").append(uri.stringValue()).append(">");
+        return sb;
+    }
+
+    private static StringBuilder appendValue(StringBuilder sb, Literal lit) {
+        sb.append('"');
+        sb.append(SPARQLUtil.encodeString(lit.getLabel()));
+        sb.append('"');
+
+        if (Literals.isLanguageLiteral(lit)) {
+            sb.append('@');
+            sb.append(lit.getLanguage().get());
+        }
+        else {
+            sb.append("^^<");
+            sb.append(lit.getDatatype().stringValue());
+            sb.append('>');
+        }
+        return sb;
+    }
+
+
+    private static StringBuilder appendValue(StringBuilder sb, PlainLiteral lit) {
+        sb.append('"');
+        sb.append(SPARQLUtil.encodeString(lit.getLabel()));
+        sb.append('"');
+
+        return sb;
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlRel.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlRel.java
@@ -1,0 +1,12 @@
+package org.semagrow.plan.rel.sparql;
+
+import org.apache.calcite.rel.RelNode;
+
+/**
+ * Created by angel on 13/7/2017.
+ */
+public interface SparqlRel extends RelNode {
+
+    SparqlImplementor.Result implement(SparqlImplementor implementor);
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlRules.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlRules.java
@@ -1,0 +1,640 @@
+package org.semagrow.plan.rel.sparql;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.plan.*;
+import org.apache.calcite.rel.InvalidRelException;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.*;
+import org.apache.calcite.rel.logical.*;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.*;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.ImmutableIntList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The set of planner rules to convert from Logical to SPARQL AST.
+ * The rules implement the logic that decides whether the endpoint can
+ * support the Logical node or not depending on the version of SPARQL and
+ * the custom function calls that supports (for example, geoSPARQL).
+ */
+public abstract class SparqlRules {
+
+    protected static final Logger LOGGER = LoggerFactory.getLogger(SparqlRules.class);
+
+    public static List<RelOptRule> rules(SparqlConvention convention) {
+        if (convention.getDialect().getVersion() == SparqlVersion.SPARQL11)
+            return sparql11(convention);
+        else
+            return sparql10(convention);
+    }
+
+    public static List<RelOptRule> sparql10(SparqlConvention convention) {
+        return ImmutableList.of(
+                new SparqlJoinRule(convention),
+                new SparqlFilterRule(convention),
+                new SparqlProjectRule(convention),
+                new SparqlAggregateRule(convention),
+                new SparqlSortRule(convention),
+                new SparqlToSemagrowConverterRule(convention));
+    }
+
+    public static List<RelOptRule> sparql11(SparqlConvention convention) {
+        return ImmutableList.of(
+                new SparqlToSemagrowConverterRule(convention),
+                new SparqlJoinRule(convention),
+                new SparqlFilterRule(convention),
+                new SparqlProjectRule(convention),
+                new SparqlAggregateRule(convention),
+                new SparqlSortRule(convention),
+                new SparqlUnionRule(convention),
+                new SparqlIntersectRule(convention),
+                new SparqlMinusRule(convention),
+                new SparqlValuesRule(convention));
+    }
+
+    private static abstract class SparqlConverterRule extends ConverterRule {
+
+        protected final SparqlConvention out;
+
+        public SparqlConverterRule(Class<? extends RelNode> clazz, RelTrait in,
+                                   SparqlConvention out, String description) {
+            this(clazz, Predicates.<RelNode>alwaysTrue(), in, out, description);
+        }
+
+        public <R extends RelNode> SparqlConverterRule(Class<R> clazz,
+                                                       Predicate<? super R> predicate,
+                                                       RelTrait in, SparqlConvention out,
+                                                       String description) {
+            super(clazz, predicate, in, out, description);
+            this.out = out;
+        }
+
+        public boolean isSupported(RexNode node) {
+            return node.accept(new SupportedCallsVisitor(out.getDialect()));
+        }
+
+        public boolean isSupported(SqlOperator op) {
+            return out.getDialect().supportsFeature(SparqlFeature.of(op));
+        }
+
+        class SupportedCallsVisitor extends RexVisitorImpl<Boolean> {
+
+            private SparqlDialect dialect;
+
+            protected SupportedCallsVisitor(SparqlDialect dialect) {
+                super(true);
+                this.dialect = Preconditions.checkNotNull(dialect);
+            }
+
+            @Override
+            public Boolean visitCall(RexCall call) {
+                return isSupported(call.op) && visitChildren(call.getOperands());
+            }
+
+            @Override
+            public Boolean visitSubQuery(RexSubQuery subQuery) {
+                return dialect.supportsSubQuery()
+                        && visitChildren(subQuery.getOperands());
+            }
+
+            @Override
+            public Boolean visitInputRef(RexInputRef inputRef) {
+                return true;
+            }
+
+            @Override
+            public Boolean visitLiteral(RexLiteral literal) {
+                return true;
+            }
+
+            private Boolean visitChildren(List<RexNode> nodes) {
+                for (RexNode o : nodes) {
+                    if (!o.accept(this))
+                        return false;
+                }
+                return true;
+            }
+        }
+
+    }
+
+    private static class SparqlJoinRule extends SparqlConverterRule {
+
+        public SparqlJoinRule(SparqlConvention out) {
+            super(LogicalJoin.class, Convention.NONE, out, "SparqlJoinRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode relNode) {
+
+            LogicalJoin join = (LogicalJoin) relNode;
+
+            JoinInfo joinInfo = JoinInfo.of(join.getLeft(), join.getRight(), join.getCondition());
+
+            if (join.getJoinType() == JoinRelType.FULL || join.getJoinType() == JoinRelType.RIGHT)
+                return null; // SPARQL does not support full outer join (yet)
+
+            if (joinInfo.isEqui()) {
+
+                RelNode left = convert(join.getLeft(), getOutTrait());
+                RelNode right = convert(join.getRight(), getOutTrait());
+                ImmutableIntList leftKeys = joinInfo.leftKeys;
+                ImmutableIntList rightKeys = joinInfo.rightKeys;
+                JoinRelType joinType = join.getJoinType();
+
+                if (joinType == JoinRelType.RIGHT) {
+                    return null;
+                    // we can also swap sides and use JoinRelType.LEFT instead but
+                    // we should make sure that join.getVariablesSet() is empty, namely
+                    // the right side does not depend on the left side.
+                }
+
+                return new SparqlEquiJoin(
+                        join.getCluster(),
+                        join.getTraitSet().replace(getOutTrait()),
+                        left,
+                        right,
+                        joinInfo.getEquiCondition(left, right, join.getCluster().getRexBuilder()),
+                        leftKeys,
+                        rightKeys,
+                        join.getVariablesSet(),
+                        joinType);
+            } else {
+                RexNode theta = joinInfo.getRemaining(join.getCluster().getRexBuilder());
+
+                if (isSupported(theta)) {
+
+                    if (join.getJoinType() == JoinRelType.INNER) {
+                        // if it's inner then create an equi-join (maybe crossjoin) and then a filter.
+
+                        RelNode left = convert(join.getLeft(), getOutTrait());
+                        RelNode right = convert(join.getRight(), getOutTrait());
+
+                        RelNode input = new SparqlEquiJoin(
+                                join.getCluster(),
+                                join.getTraitSet().replace(getOutTrait()),
+                                left,
+                                right,
+                                joinInfo.getEquiCondition(left, right, join.getCluster().getRexBuilder()),
+                                joinInfo.leftKeys,
+                                joinInfo.rightKeys,
+                                join.getVariablesSet(),
+                                join.getJoinType());
+
+                        return new SparqlFilter(
+                                input.getCluster(),
+                                input.getTraitSet().replace(getOutTrait()),
+                                input,
+                                theta);
+                    } else {
+                        assert join.getJoinType() == JoinRelType.LEFT;
+                        try {
+                            return new SparqlThetaJoin(
+                                    join.getCluster(),
+                                    join.getTraitSet().replace(out),
+                                    convert(join.getLeft(), out),
+                                    convert(join.getRight(), out),
+                                    join.getCondition(),
+                                    join.getVariablesSet(),
+                                    join.getJoinType());
+                        } catch (InvalidRelException e) {
+                            LOGGER.debug(e.toString());
+                            return null;
+                        }
+                    }
+                }
+            }
+            return null;
+        }
+    }
+
+    public static class SparqlEquiJoin extends EquiJoin implements SparqlRel {
+
+
+        public SparqlEquiJoin(RelOptCluster cluster, RelTraitSet traits,
+                              RelNode left, RelNode right, RexNode condition,
+                              ImmutableIntList leftKeys, ImmutableIntList rightKeys,
+                              Set<CorrelationId> variablesSet, JoinRelType joinType) {
+            super(cluster, traits, left, right, condition, leftKeys, rightKeys, variablesSet, joinType);
+        }
+
+        @Override
+        public Join copy(RelTraitSet traitSet, RexNode condition,
+                         RelNode left, RelNode right, JoinRelType joinType,
+                         boolean semiJoinDone) {
+
+
+            final JoinInfo joinInfo = JoinInfo.of(left, right, condition);
+            assert joinInfo.isEqui();
+
+            return new SparqlRules.SparqlEquiJoin(getCluster(), traitSet, left, right,
+                    condition, joinInfo.leftKeys, joinInfo.rightKeys, variablesSet, joinType);
+
+        }
+
+        public SparqlImplementor.Result implement(SparqlImplementor implementor) { return implementor.implement(this); }
+    }
+
+    public static class SparqlThetaJoin extends Join implements SparqlRel {
+
+        protected SparqlThetaJoin(RelOptCluster cluster, RelTraitSet traitSet,
+                           RelNode left, RelNode right, RexNode condition,
+                           Set<CorrelationId> variablesSet, JoinRelType joinType)
+                throws InvalidRelException {
+            super(cluster,
+                    traitSet,
+                    left,
+                    right,
+                    condition,
+                    variablesSet,
+                    joinType);
+        }
+
+        @Override
+        public Join copy(RelTraitSet traitSet, RexNode condition,
+            RelNode left, RelNode right, JoinRelType joinType,
+            boolean semiJoinDone) {
+
+            try {
+                return new SparqlRules.SparqlThetaJoin(getCluster(), traitSet, left, right,
+                        condition, variablesSet, joinType);
+            } catch (InvalidRelException e) {
+                // Semantic error not possible. Must be a bug. Convert to
+                // internal error.
+                throw new AssertionError(e);
+            }
+        }
+
+        public SparqlImplementor.Result implement(SparqlImplementor implementor) { return implementor.implement(this); }
+
+    }
+
+    private static class SparqlFilterRule extends SparqlConverterRule {
+
+        public SparqlFilterRule(SparqlConvention out) {
+            super(LogicalFilter.class, Convention.NONE, out, "SparqlFilterRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode relNode) {
+
+            LogicalFilter filter = (LogicalFilter) relNode;
+
+            if (!isSupported(filter.getCondition()))
+                return null;
+
+
+            return new SparqlRules.SparqlFilter(
+                    filter.getCluster(),
+                    filter.getTraitSet().replace(out),
+                    convert(filter.getInput(), out),
+                    filter.getCondition());
+        }
+    }
+
+    public static class SparqlFilter extends Filter implements SparqlRel {
+
+        protected SparqlFilter(RelOptCluster cluster, RelTraitSet traits, RelNode child, RexNode condition) {
+            super(cluster, traits, child, condition);
+            assert getConvention() instanceof SparqlConvention;
+        }
+
+        @Override
+        public Filter copy(RelTraitSet relTraitSet, RelNode relNode, RexNode rexNode) {
+            return new SparqlFilter(getCluster(), relTraitSet, relNode, rexNode);
+        }
+
+        public SparqlImplementor.Result implement(SparqlImplementor implementor) { return implementor.implement(this); }
+
+    }
+
+    private static class SparqlProjectRule extends SparqlConverterRule {
+
+        public SparqlProjectRule(SparqlConvention out) {
+            super(LogicalProject.class, Convention.NONE, out, "SparqlProjectRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode relNode) {
+
+            LogicalProject project = (LogicalProject) relNode;
+
+            for (RexNode p : project.getProjects()) {
+                if (!isSupported(p))
+                    return null;
+            }
+
+            // check condition (if can be transformed)
+            return new SparqlProject(
+                    project.getCluster(),
+                    project.getTraitSet().replace(out),
+                    convert(project.getInput(), out),
+                    project.getProjects(),
+                    project.getRowType());
+        }
+    }
+
+    public static class SparqlProject extends Project implements SparqlRel {
+
+        protected SparqlProject(RelOptCluster cluster,
+                                RelTraitSet traits,
+                                RelNode input,
+                                List<? extends RexNode> projects,
+                                RelDataType rowType) {
+            super(cluster, traits, input, projects, rowType);
+        }
+
+        @Override
+        public Project copy(RelTraitSet relTraitSet, RelNode relNode, List<RexNode> list, RelDataType relDataType) {
+            return new SparqlProject(getCluster(), relTraitSet, relNode, list, relDataType);
+        }
+
+        public SparqlImplementor.Result implement(SparqlImplementor implementor) { return implementor.implement(this); }
+
+    }
+
+    private static class SparqlSortRule extends SparqlConverterRule {
+
+        public SparqlSortRule(SparqlConvention out) {
+            super(LogicalSort.class, Convention.NONE, out, "SparqlSortRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode relNode) {
+
+            LogicalSort sort = (LogicalSort) relNode;
+
+            // check condition (if can be transformed)
+            return new SparqlSort(
+                    sort.getCluster(),
+                    sort.getTraitSet().replace(out),
+                    convert(sort.getInput(),out),
+                    sort.getCollation(),
+                    sort.offset,
+                    sort.fetch);
+        }
+    }
+
+    public static class SparqlSort extends Sort implements SparqlRel {
+
+
+        public SparqlSort(RelOptCluster cluster, RelTraitSet traits, RelNode child, RelCollation collation, RexNode offset, RexNode fetch) {
+            super(cluster, traits, child, collation, offset, fetch);
+        }
+
+        @Override
+        public Sort copy(RelTraitSet relTraitSet, RelNode relNode, RelCollation relCollation, RexNode rexNode, RexNode rexNode1) {
+            return new SparqlSort(getCluster(), relTraitSet, relNode, relCollation, rexNode, rexNode1);
+        }
+
+        public SparqlImplementor.Result implement(SparqlImplementor implementor) { return implementor.implement(this); }
+
+    }
+
+    private static class SparqlUnionRule extends SparqlConverterRule {
+
+        public SparqlUnionRule(SparqlConvention out) {
+            super(LogicalUnion.class, Convention.NONE, out, "SparqlUnionRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode relNode) {
+
+            LogicalUnion node = (LogicalUnion) relNode;
+
+            return new SparqlUnion(
+                    relNode.getCluster(),
+                    relNode.getTraitSet().replace(getOutTrait()),
+                    convertList(node.getInputs(), getOutTrait()),
+                    node.all);
+        }
+    }
+
+    public static class SparqlUnion extends Union implements SparqlRel {
+
+        protected SparqlUnion(RelOptCluster cluster, RelTraitSet traits, List<RelNode> inputs, boolean all) {
+            super(cluster, traits, inputs, all);
+        }
+
+        @Override
+        public SetOp copy(RelTraitSet relTraitSet, List<RelNode> list, boolean b) {
+            return new SparqlUnion(getCluster(), relTraitSet, list, b);
+        }
+
+        public SparqlImplementor.Result implement(SparqlImplementor implementor) { return implementor.implement(this); }
+
+    }
+
+    private static class SparqlIntersectRule extends SparqlConverterRule {
+
+        public SparqlIntersectRule(SparqlConvention out) {
+            super(LogicalIntersect.class, Convention.NONE, out, "SparqlIntersectRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode relNode) {
+            LogicalIntersect node = (LogicalIntersect) relNode;
+
+            return new SparqlIntersect(
+                    relNode.getCluster(),
+                    relNode.getTraitSet().replace(getOutTrait()),
+                    convertList(node.getInputs(), getOutTrait()),
+                    node.all);
+        }
+    }
+
+    public static class SparqlIntersect extends Intersect implements SparqlRel {
+
+        public SparqlIntersect(RelOptCluster cluster, RelTraitSet traits, List<RelNode> inputs, boolean all) {
+            super(cluster, traits, inputs, all);
+        }
+
+        @Override
+        public SetOp copy(RelTraitSet relTraitSet, List<RelNode> list, boolean b) {
+            return new SparqlIntersect(getCluster(), relTraitSet ,list, b);
+        }
+
+        public SparqlImplementor.Result implement(SparqlImplementor implementor) { return implementor.implement(this); }
+
+    }
+
+    private static class SparqlMinusRule extends SparqlConverterRule {
+
+        public SparqlMinusRule(SparqlConvention out) {
+            super(LogicalMinus.class, Convention.NONE, out, "SparqlMinusRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode relNode) {
+            LogicalMinus node = (LogicalMinus) relNode;
+            return new SparqlMinus(
+                    relNode.getCluster(),
+                    relNode.getTraitSet().replace(getOutTrait()),
+                    convertList(node.getInputs(), getOutTrait()),
+                    node.all);
+        }
+    }
+
+    public static class SparqlMinus extends Minus implements SparqlRel {
+
+        public SparqlMinus(RelOptCluster cluster, RelTraitSet traits, List<RelNode> inputs, boolean all) {
+            super(cluster, traits, inputs, all);
+        }
+
+        @Override
+        public SetOp copy(RelTraitSet relTraitSet, List<RelNode> list, boolean b) {
+            return new SparqlMinus(getCluster(), relTraitSet, list, b);
+        }
+
+        public SparqlImplementor.Result implement(SparqlImplementor implementor) { return implementor.implement(this); }
+
+    }
+
+    private static class SparqlAggregateRule extends SparqlConverterRule {
+
+        public SparqlAggregateRule(SparqlConvention out) {
+            super(LogicalAggregate.class, Convention.NONE, out, "SparqlAggregateRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode relNode) {
+            LogicalAggregate node = (LogicalAggregate) relNode;
+
+            if (node.getAggCallList().isEmpty() &&
+                isEveryColumnInGroupSet(node.getRowType(), node.getGroupSet())) {
+
+                return new SparqlDistinct(
+                        relNode.getCluster(),
+                        relNode.getTraitSet().replace(getOutTrait()),
+                        convert(node.getInput(), getOutTrait()));
+            } else {
+
+                if (out.getDialect().getVersion() == SparqlVersion.SPARQL10)
+                    return null; //groupings are not supported in Sparql10 (only distinct)
+
+                for (AggregateCall call : node.getAggCallList())
+                    if (!isSupported(call.getAggregation()))
+                        return null;
+
+                return new SparqlAggregate(
+                        relNode.getCluster(),
+                        relNode.getTraitSet().replace(getOutTrait()),
+                        convert(node.getInput(), getOutTrait()),
+                        node.indicator,
+                        node.getGroupSet(),
+                        node.getGroupSets(),
+                        node.getAggCallList());
+            }
+        }
+
+
+        private boolean isEveryColumnInGroupSet(RelDataType rowType, ImmutableBitSet groupSet) {
+            for (RelDataTypeField f : rowType.getFieldList()) {
+                if (!groupSet.get(f.getIndex()))
+                    return false;
+            }
+            return true;
+        }
+    }
+
+    public static class SparqlDistinct extends Aggregate implements SparqlRel {
+
+        protected SparqlDistinct(RelOptCluster cluster, RelTraitSet traits, RelNode child) {
+            super(cluster,
+                    traits,
+                    child,
+                    false,
+                    ImmutableBitSet.range(child.getRowType().getFieldCount()),
+                    null,
+                    ImmutableList.of());
+        }
+
+        @Override
+        public Aggregate copy(RelTraitSet traitSet,
+                              RelNode input,
+                              boolean indicator,
+                              ImmutableBitSet groupSet,
+                              List<ImmutableBitSet> groupSets, List<AggregateCall> aggCalls) {
+            return copy(traitSet, input);
+        }
+
+        public SparqlDistinct copy(RelTraitSet traitSet, RelNode input) {
+            return new SparqlDistinct(getCluster(), traitSet, input);
+        }
+
+        public SparqlImplementor.Result implement(SparqlImplementor implementor) { return implementor.implement(this); }
+
+    }
+
+    public static class SparqlAggregate extends Aggregate implements SparqlRel {
+
+        protected SparqlAggregate(RelOptCluster cluster, RelTraitSet traits, RelNode child, boolean indicator,
+                                  ImmutableBitSet groupSet, List<ImmutableBitSet> groupSets,
+                                  List<AggregateCall> aggCalls) {
+            super(cluster, traits, child, indicator, groupSet, groupSets, aggCalls);
+        }
+
+        @Override
+        public Aggregate copy(RelTraitSet relTraitSet, RelNode relNode, boolean b,
+                              ImmutableBitSet immutableBitSet, List<ImmutableBitSet> list,
+                              List<AggregateCall> list1) {
+            return new SparqlAggregate(
+                    getCluster(),
+                    relTraitSet,
+                    relNode,
+                    b,
+                    immutableBitSet,
+                    list,
+                    list1);
+        }
+
+        public SparqlImplementor.Result implement(SparqlImplementor implementor) { return implementor.implement(this); }
+
+    }
+
+    private static class SparqlValuesRule extends SparqlConverterRule {
+
+        public SparqlValuesRule(SparqlConvention out) {
+            super(LogicalValues.class, Convention.NONE, out, "SparqlValuesRule");
+        }
+
+        @Override
+        public RelNode convert(RelNode relNode) {
+
+            LogicalValues node = (LogicalValues) relNode;
+
+            return new SparqlValues(
+                    relNode.getCluster(),
+                    relNode.getRowType(),
+                    node.getTuples(),
+                    relNode.getTraitSet().replace(getOutTrait()));
+        }
+    }
+
+    public static class SparqlValues extends Values implements SparqlRel {
+
+        protected SparqlValues(
+                RelOptCluster cluster,
+                RelDataType rowType,
+                ImmutableList<ImmutableList<RexLiteral>> tuples,
+                RelTraitSet traits) {
+            super(cluster, rowType, tuples, traits);
+        }
+
+        public SparqlImplementor.Result implement(SparqlImplementor implementor) { return implementor.implement(this); }
+
+    }
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlService.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlService.java
@@ -1,0 +1,30 @@
+package org.semagrow.plan.rel.sparql;
+
+import com.google.common.base.Preconditions;
+import org.apache.calcite.plan.ConventionTraitDef;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.convert.ConverterImpl;
+
+/**
+ * Created by angel on 13/7/2017.
+ */
+public class SparqlService
+        extends ConverterImpl
+        implements SparqlRel
+{
+    private String ref;
+
+    protected SparqlService(RelOptCluster cluster, RelTraitSet traits, RelNode child) {
+        super(cluster, ConventionTraitDef.INSTANCE, traits, child);
+
+        assert getConvention() instanceof SparqlConvention;
+        assert getInput().getConvention() instanceof SparqlConvention;
+        SparqlConvention conv = (SparqlConvention) getInput().getConvention();
+        this.ref = Preconditions.checkNotNull(conv.getEndpoint());
+    }
+
+    public SparqlImplementor.Result implement(SparqlImplementor implementor) { return implementor.implement(this); }
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlStatementPattern.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlStatementPattern.java
@@ -1,0 +1,94 @@
+package org.semagrow.plan.rel.sparql;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.util.ImmutableIntList;
+import org.apache.calcite.util.mapping.Mappings;
+import org.semagrow.plan.rel.StatementScan;
+import org.semagrow.plan.rel.schema.RelOptDataset;
+
+import java.util.List;
+import java.util.Map;
+
+public class SparqlStatementPattern extends StatementScan implements SparqlRel {
+
+    private RelOptDataset dataset;
+
+    private RelDataType rowType;
+
+    public ImmutableIntList projects;
+
+    public Map<Integer,RexNode> filters;
+
+    protected SparqlStatementPattern(
+            RelOptCluster cluster,
+            RelTraitSet traitSet,
+            RelOptDataset dataset,
+            RelDataType type,
+            Map<Integer, RexNode> filters,
+            List<Integer> projects)
+    {
+        super(cluster, traitSet, dataset);
+        this.dataset = dataset;
+        this.rowType = type;
+        this.filters = ImmutableMap.copyOf(filters);
+        this.projects = ImmutableIntList.copyOf(projects);
+    }
+
+    @Override protected RelDataType deriveRowType() {
+
+        return dataset.getRowType(getCluster().getTypeFactory());
+    }
+
+    @Override public RelWriter explainTerms(RelWriter pw) {
+        return super.explainTerms(pw);
+    }
+
+
+    @Override
+    public SparqlImplementor.Result implement(SparqlImplementor implementor) {
+        return implementor.implement(this);
+    }
+
+
+    public Mappings.TargetMapping getMapping() {
+        return Mappings.target(projects,
+                dataset.getRowType(getCluster().getTypeFactory()).getFieldCount());
+    }
+
+    static public SparqlStatementPattern create(RelOptCluster cluster,
+                                              RelOptDataset dataset,
+                                              RelTraitSet traitSet,
+                                              RelDataType rowType,
+                                              Map<Integer, RexNode> filters,
+                                              List<Integer> projects)
+    {
+        if (projects == null)
+            projects = Mappings.asList(Mappings.createIdentity(rowType.getFieldCount()));
+
+        return new SparqlStatementPattern(cluster,
+                traitSet,
+                dataset,
+                rowType,
+                filters,
+                projects);
+    }
+
+    static public SparqlStatementPattern create(RelOptCluster cluster,
+                                                RelOptDataset dataset,
+                                                RelTraitSet traitSet)
+    {
+        RelDataType rowType = dataset.getRowType(cluster.getTypeFactory());
+
+        return create(cluster, dataset,
+                traitSet,
+                rowType,
+                ImmutableMap.of(),
+                Mappings.asList(Mappings.createIdentity(rowType.getFieldCount())));
+    }
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlStatementPatternRules.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlStatementPatternRules.java
@@ -1,0 +1,250 @@
+package org.semagrow.plan.rel.sparql;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.logical.LogicalValues;
+import org.apache.calcite.rex.*;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.calcite.util.mapping.Mapping;
+import org.apache.calcite.util.mapping.Mappings;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+public  class SparqlStatementPatternRules {
+
+    private static class SparqlFilterStatementScanRule extends RelOptRule {
+
+        private SparqlFilterStatementScanRule(RelBuilderFactory builderFactory) {
+            super(operand(Filter.class,
+                    operand(SparqlStatementPattern.class, none())),
+                    builderFactory, null);
+        }
+
+        // Utility function
+        static public RexNode classifyFilters(RexBuilder builder,
+                                              RexNode condition,
+                                              List<RexNode> equal) {
+            final List<RexNode> nonEqualList = new ArrayList<>();
+            List<RexNode> conjuncts = RelOptUtil.conjunctions(condition);
+
+            classifyFilters(conjuncts, equal, nonEqualList);
+
+            return RexUtil.composeConjunction(builder, nonEqualList, false);
+        }
+
+        private static void classifyFilters(List<RexNode> conjuncts,
+                                            List<RexNode> simpleEqual,
+                                            List<RexNode> nonEqualList) {
+            for (RexNode exp : conjuncts) {
+                if (isSimpleEqual(exp)) {
+                    simpleEqual.add(exp);
+                } else {
+                    nonEqualList.add(exp);
+                }
+            }
+        }
+
+        private static boolean isSimpleEqual(RexNode exp) {
+
+            if (exp instanceof RexCall &&
+                    exp.isA(SqlKind.EQUALS)) {
+                RexCall eq = (RexCall) exp;
+                RexNode left = eq.operands.get(0);
+                RexNode right = eq.operands.get(1);
+
+                RexNode other = null;
+
+                if (left instanceof RexInputRef)
+                    other = right;
+                else if (right instanceof RexInputRef)
+                    other = left;
+
+                return other != null &&
+                        ((other instanceof RexLiteral) || (other instanceof RexInputRef));
+            }
+
+            return false;
+        }
+
+        private static Map<Integer,RexNode> equalToMap(Iterable<? extends RexNode> nodes) {
+            ImmutableMap.Builder<Integer,RexNode> out = ImmutableMap.builder();
+
+            for (RexNode n : nodes) {
+                if (n instanceof RexCall && n.isA(SqlKind.EQUALS)) {
+                    RexCall eq = (RexCall) n;
+                    RexNode left = eq.operands.get(0);
+                    RexNode right = eq.operands.get(1);
+
+                    if (RexUtil.eq(left, right))
+                        continue;
+
+                    RexNode ref = (left instanceof RexInputRef) ? left : right;
+                    RexNode other = (left instanceof RexInputRef) ? right : left;
+                    if (ref instanceof RexInputRef) {
+                        RexInputRef v = (RexInputRef)ref;
+                        out.put(v.getIndex(), other);
+                    }
+                }
+            }
+            return out.build();
+        }
+
+        private static boolean mergeFilters(Map<Integer, RexNode> filter1,
+                                            Map<Integer, RexNode> filter2,
+                                            Map<Integer, RexNode> merged) {
+
+
+            Map<Integer, RexNode> literals    = new HashMap<>();
+            Map<Integer, RexNode> nonLiterals = new HashMap<>();
+
+
+            for (Map.Entry<Integer, RexNode> e : filter1.entrySet()) {
+                if (e.getValue() instanceof RexLiteral)
+                    literals.put(e.getKey(), e.getValue());
+            }
+
+            for (Map.Entry<Integer, RexNode> e : filter2.entrySet()) {
+
+                if (literals.containsKey(e.getKey()))
+                    return false;
+
+                if (e.getValue() instanceof RexLiteral)
+                    literals.put(e.getKey(), e.getValue());
+            }
+
+            //FIXME: restructure this ugly code
+
+            for (Map.Entry<Integer, RexNode> e : filter1.entrySet()) {
+                if (e.getValue() instanceof RexInputRef) {
+                    RexInputRef r = (RexInputRef) e.getValue();
+
+                    if (literals.containsKey(e.getKey())) {
+                        if (literals.containsKey(r.getIndex())) {
+                            if (!RexUtil.eq(literals.get(r.getIndex()), literals.get(e.getKey())))
+                                return false;
+                        } else
+                            literals.put(r.getIndex(), literals.get(e.getKey()));
+
+                    } else if (literals.containsKey(r.getIndex())) {
+                        literals.put(e.getKey(), literals.get(r.getIndex()));
+                    } else {
+                        nonLiterals.put(e.getKey(), e.getValue());
+                    }
+                }
+            }
+
+            for (Map.Entry<Integer, RexNode> e : filter2.entrySet()) {
+                if (e.getValue() instanceof RexInputRef) {
+                    RexInputRef r = (RexInputRef) e.getValue();
+
+                    if (literals.containsKey(e.getKey())) {
+                        if (literals.containsKey(r.getIndex())) {
+                            if (!RexUtil.eq(literals.get(r.getIndex()), literals.get(e.getKey())))
+                                return false;
+                        } else
+                            literals.put(r.getIndex(), literals.get(e.getKey()));
+
+                    } else if (literals.containsKey(r.getIndex())) {
+                        literals.put(e.getKey(), literals.get(r.getIndex()));
+                    } else {
+                        nonLiterals.put(e.getKey(), e.getValue());
+                    }
+                }
+            }
+
+            merged.putAll(literals);
+            merged.putAll(nonLiterals); // check if there are equalities {x} = {y} && {y} = {x}
+
+            return true;
+        }
+
+        @Override
+        public void onMatch(RelOptRuleCall call) {
+            final Filter filter = call.rel(0);
+            final SparqlStatementPattern pattern = call.rel(1);
+
+            List<RexNode> equalities = new ArrayList<>();
+
+            final Mappings.TargetMapping mapping = pattern.getMapping();
+
+            RexNode cond = classifyFilters(
+                    filter.getCluster().getRexBuilder(),
+                    filter.getCondition(),
+                    equalities);
+
+            Iterable<RexNode> equalities2 = RexUtil.apply(mapping.inverse(), equalities);
+
+            Map<Integer, RexNode> filters = equalToMap(equalities2);
+            Map<Integer, RexNode> merged = new HashMap<>();
+
+            boolean alwaysFalse = mergeFilters(filters, pattern.filters, merged);
+
+            RelNode rel;
+
+            if (!alwaysFalse) {
+                rel = SparqlStatementPattern.create(
+                        pattern.getCluster(),
+                        pattern.getDataset(),
+                        pattern.getTraitSet(),
+                        pattern.getRowType(),
+                        merged,
+                        pattern.projects);
+            } else
+                rel = LogicalValues.createEmpty(pattern.getCluster(), pattern.getRowType());
+
+            if (cond.isAlwaysTrue()) {
+                // ignore filter
+                RelBuilder builder = call.builder();
+                builder.push(rel);
+                rel = builder.filter(cond).build();
+            }
+
+            call.transformTo(rel);
+        }
+    }
+
+    private static class SparqlProjectStatementScanRule extends RelOptRule {
+
+        private SparqlProjectStatementScanRule() {
+            super(operand(Project.class, null, p -> p.isMapping(),
+                      operand(SparqlStatementPattern.class, none())));
+        }
+
+        @Override
+        public void onMatch(RelOptRuleCall call) {
+
+            final Project project = call.rel(0);
+            final SparqlStatementPattern pattern = call.rel(1);
+            final Mappings.TargetMapping mapping = project.getMapping();
+
+            if (mapping == null) {
+                return;
+            }
+
+            List<Integer> projects = Mappings.apply((Mapping)mapping, pattern.projects);
+
+            RelNode rel = SparqlStatementPattern.create(
+                    pattern.getCluster(),
+                    pattern.getDataset(),
+                    pattern.getTraitSet(),
+                    project.getRowType(),
+                    pattern.filters,
+                    projects);
+
+            call.transformTo(rel);
+        }
+
+    }
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlStdOperatorTable.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlStdOperatorTable.java
@@ -1,0 +1,172 @@
+package org.semagrow.plan.rel.sparql;
+
+import org.apache.calcite.sql.*;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.*;
+import org.apache.calcite.sql.util.ReflectiveSqlOperatorTable;
+import org.semagrow.plan.rel.type.RDFTypes;
+
+/**
+ * Created by angel on 16/7/2017.
+ */
+public class SparqlStdOperatorTable extends ReflectiveSqlOperatorTable {
+
+    public static final SparqlFunction IS_NUMERIC;//sparql10
+    public static final SparqlFunction IS_LITERAL;//sparql10
+    public static final SparqlFunction IS_RESOURCE;//sparql10
+    public static final SparqlFunction IS_URI;//sparql10
+    public static final SparqlFunction LANG_MATCHES;//sparql10
+    public static final SparqlFunction LANG;//sparql10
+    public static final SparqlFunction LABEL;
+    public static final SparqlFunction DATATYPE;
+
+    public static final SparqlFunction SAMETERM = null; //sparql10
+    public static final SparqlFunction STR = null;//sparql10
+    public static final SparqlFunction BNODE = null;//sparql11
+    public static final SparqlFunction STRDT = null;
+    public static final SparqlFunction STRLANG = null;
+    public static final SparqlFunction UUID = null;
+    public static final SparqlFunction STRUUID = null;
+    public static final SparqlFunction REGEX = null;
+    public static final SparqlFunction STRLEN = null;
+    public static final SparqlFunction STRSTARTS = null;
+    public static final SparqlFunction STRENDS = null;
+    public static final SparqlFunction STRBEFORE = null;
+    public static final SparqlFunction STRAFTER = null;
+    public static final SparqlFunction ENCODE_FOR_URI = null;
+    public static final SqlFunction SUBSTR  = sparql11(SqlStdOperatorTable.SUBSTRING);
+    public static final SqlFunction UCASE   = sparql11(SqlStdOperatorTable.UPPER);
+    public static final SqlFunction LCASE   = sparql11(SqlStdOperatorTable.LOWER);
+    public static final SqlOperator CONCAT  = sparql11(SqlStdOperatorTable.CONCAT);
+    public static final SqlFunction REPLACE = sparql11(SqlStdOperatorTable.REPLACE);
+    public static final SqlFunction CONTAINS = null;
+
+    public static final SqlOperator AND = sparql10(SqlStdOperatorTable.AND);
+    public static final SqlOperator OR  = sparql10(SqlStdOperatorTable.OR);
+    public static final SqlOperator NOT = sparql10(SqlStdOperatorTable.NOT);
+
+    public static final SqlOperator EQUALS = sparql10(SqlStdOperatorTable.EQUALS);
+    public static final SqlOperator GREATER_THAN = sparql10(SqlStdOperatorTable.GREATER_THAN);
+    public static final SqlOperator LESS_THAN = sparql10(SqlStdOperatorTable.LESS_THAN);
+    public static final SqlOperator LESS_THAN_OR_EQUAL = sparql10(SqlStdOperatorTable.LESS_THAN_OR_EQUAL);
+    public static final SqlOperator GREATER_THAN_OR_EQUAL = sparql10(SqlStdOperatorTable.GREATER_THAN_OR_EQUAL);
+
+    public static final SqlFunction ABS = sparql11(SqlStdOperatorTable.ABS);
+    public static final SqlFunction CEIL = sparql11(SqlStdOperatorTable.CEIL);
+    public static final SqlFunction FLOOR = sparql11(SqlStdOperatorTable.FLOOR);
+    public static final SqlFunction RAND = sparql11(SqlStdOperatorTable.RAND);
+    public static final SqlFunction ROUND = sparql11(SqlStdOperatorTable.ROUND);
+
+    public static final SqlFunction NOW = sparql11(SqlStdOperatorTable.CURRENT_TIME);
+    public static final SqlFunction YEAR = sparql11(SqlStdOperatorTable.YEAR);
+    public static final SqlFunction MONTH = sparql11(SqlStdOperatorTable.MONTH);
+    public static final SqlFunction DAY = sparql11(SqlStdOperatorTable.DAYOFYEAR);
+    public static final SqlFunction HOURS = sparql11(SqlStdOperatorTable.HOUR);
+    public static final SqlFunction MINUTES = sparql11(SqlStdOperatorTable.MINUTE);
+    public static final SqlFunction SECONDS = sparql11(SqlStdOperatorTable.SECOND);
+    public static final SqlFunction TIMEZONE = null;
+    public static final SqlFunction TZ = null;
+
+    public static final SparqlFunction MD5 = null;
+    public static final SparqlFunction SHA1 = null;
+    public static final SparqlFunction SHA256 = null;
+    public static final SparqlFunction SHA384 = null;
+    public static final SparqlFunction SHA512 = null;
+
+    public static final SqlOperator PLUS = sparql10(SqlStdOperatorTable.PLUS);
+    public static final SqlOperator MINUS = sparql10(SqlStdOperatorTable.MINUS);
+    public static final SqlOperator MULTIPLY = sparql10(SqlStdOperatorTable.MULTIPLY);
+    public static final SqlOperator DIVIDE = sparql10(SqlStdOperatorTable.DIVIDE);
+
+    public static final SqlOperator LIKE = sparql11(SqlStdOperatorTable.LIKE);
+    public static final SqlFunction COALESCE = sparql11(SqlStdOperatorTable.COALESCE);
+    public static final SqlOperator BOUND = sparql10(SqlStdOperatorTable.IS_NOT_NULL);
+
+    public static final SqlOperator IF = sparql11(SqlStdOperatorTable.CASE);
+
+    public static final SqlAggFunction COUNT = sparql11(SqlStdOperatorTable.COUNT);
+    public static final SqlAggFunction SUM   = sparql11(SqlStdOperatorTable.SUM);
+    public static final SqlAggFunction AVG   = sparql11(SqlStdOperatorTable.AVG);
+    public static final SqlAggFunction MAX   = sparql11(SqlStdOperatorTable.MAX);
+    public static final SqlAggFunction MIN   = sparql11(SqlStdOperatorTable.MIN);
+    public static final SqlAggFunction SAMPLE;
+    public static final SqlAggFunction GROUPCONCAT;
+
+
+    static {
+        IS_NUMERIC  = new SparqlFunction("ISNUMERIC", ReturnTypes.BOOLEAN_NOT_NULL, (SqlOperandTypeInference)null, OperandTypes.NUMERIC_INTEGER, SqlFunctionCategory.STRING, SparqlVersion.SPARQL10);
+        IS_LITERAL  = new SparqlFunction("ISLITERAL", ReturnTypes.BOOLEAN_NOT_NULL, (SqlOperandTypeInference)null, OperandTypes.NUMERIC_INTEGER, SqlFunctionCategory.STRING, SparqlVersion.SPARQL10);
+        IS_RESOURCE = new SparqlFunction("ISRESOURCE", ReturnTypes.BOOLEAN_NOT_NULL, (SqlOperandTypeInference)null, OperandTypes.NUMERIC_INTEGER, SqlFunctionCategory.STRING, SparqlVersion.SPARQL10);
+        IS_URI      = new SparqlFunction("ISURI", ReturnTypes.BOOLEAN_NOT_NULL, (SqlOperandTypeInference)null, OperandTypes.NUMERIC_INTEGER, SqlFunctionCategory.STRING, SparqlVersion.SPARQL10);
+        LANG_MATCHES= new SparqlFunction("LANGMATCHES", ReturnTypes.BOOLEAN_NOT_NULL, (SqlOperandTypeInference)null, OperandTypes.NUMERIC_INTEGER, SqlFunctionCategory.STRING, SparqlVersion.SPARQL10);
+
+        LANG     = new SparqlFunction("LANG", ReturnTypes.explicit(RDFTypes.PLAIN_LITERAL), (SqlOperandTypeInference)null, OperandTypes.NUMERIC_INTEGER, SqlFunctionCategory.STRING, SparqlVersion.SPARQL10);
+        LABEL    = new SparqlFunction("LABEL", ReturnTypes.explicit(RDFTypes.PLAIN_LITERAL), (SqlOperandTypeInference)null, OperandTypes.NUMERIC_INTEGER, SqlFunctionCategory.STRING, SparqlVersion.SPARQL10);
+        DATATYPE = new SparqlFunction("DATATYPE", ReturnTypes.explicit(RDFTypes.PLAIN_LITERAL), (SqlOperandTypeInference)null, OperandTypes.NUMERIC_INTEGER, SqlFunctionCategory.STRING, SparqlVersion.SPARQL10);
+
+        SAMPLE      = new SparqlSampleAggFunction();
+        GROUPCONCAT = new SparqlGroupConcatAggFunction();
+    }
+
+    public static SqlOperator makeSparqlFunction(String uri, int params) {
+        return new SparqlIRIFunction(
+                uri,
+                ReturnTypes.ARG0,
+                null,
+                OperandTypes.VARIADIC,
+                SparqlVersion.SPARQL10);
+    }
+
+    static <T> T sparql10(T op) { return SparqlFeature.sparql10(op); }
+
+    static <T> T sparql11(T op) { return SparqlFeature.sparql11(op); }
+
+    static class SparqlSampleAggFunction extends SqlAggFunction {
+
+        protected SparqlSampleAggFunction() {
+            super("SAMPLE",
+                null,
+                SqlKind.OTHER_FUNCTION,
+                ReturnTypes.ARG0,
+                null,
+                OperandTypes.ANY,
+                SqlFunctionCategory.USER_DEFINED_FUNCTION,
+                false,
+                false);
+        }
+    }
+
+    static class SparqlGroupConcatAggFunction extends SqlAggFunction {
+
+        protected SparqlGroupConcatAggFunction() {
+            super("GROUPCONCAT",
+                null,
+                SqlKind.OTHER_FUNCTION,
+                ReturnTypes.ARG0,
+                null,
+                OperandTypes.ANY,
+                SqlFunctionCategory.USER_DEFINED_FUNCTION,
+                false,
+                false);
+        }
+    }
+
+    static class SparqlIRIFunction extends SparqlFunction {
+
+        public SparqlIRIFunction(String name,
+                                 SqlReturnTypeInference returnTypeInference,
+                                 SqlOperandTypeInference operandTypeInference,
+                                 SqlOperandTypeChecker operandTypeChecker,
+                                 SparqlVersion requiredVersion) {
+            super(name,
+                    returnTypeInference,
+                    operandTypeInference,
+                    operandTypeChecker,
+                    requiredVersion);
+        }
+
+        @Override public boolean isStandard() { return false; }
+    }
+
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlToSemagrowConverter.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlToSemagrowConverter.java
@@ -1,0 +1,30 @@
+package org.semagrow.plan.rel.sparql;
+
+import org.apache.calcite.plan.ConventionTraitDef;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.convert.ConverterImpl;
+import org.semagrow.plan.rel.semagrow.SemagrowRel;
+
+import java.util.List;
+
+/**
+ * Created by angel on 17/7/2017.
+ */
+public class SparqlToSemagrowConverter extends ConverterImpl
+        implements SemagrowRel
+{
+    protected SparqlToSemagrowConverter(RelOptCluster cluster, RelTraitSet traits, RelNode child) {
+        super(cluster, ConventionTraitDef.INSTANCE, traits, child);
+
+        assert child.getConvention() instanceof SparqlConvention;
+
+    }
+
+    @Override public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+        return new SparqlToSemagrowConverter(getCluster(), traitSet, sole(inputs));
+    }
+
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlToSemagrowConverterRule.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlToSemagrowConverterRule.java
@@ -1,0 +1,24 @@
+package org.semagrow.plan.rel.sparql;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.convert.ConverterRule;
+import org.semagrow.plan.rel.semagrow.SemagrowConvention;
+
+/**
+ * Created by angel on 17/7/2017.
+ */
+public class SparqlToSemagrowConverterRule extends ConverterRule {
+
+    SparqlToSemagrowConverterRule(SparqlConvention out) {
+        super(RelNode.class, out, SemagrowConvention.INSTANCE,
+                "SparqltoSemagrowConverterRule");
+    }
+
+    @Override
+    public RelNode convert(RelNode rel) {
+        return new SparqlToSemagrowConverter(rel.getCluster(),
+                rel.getTraitSet().replace(SemagrowConvention.INSTANCE),
+                rel);
+    }
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlToSparqlConverterRule.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlToSparqlConverterRule.java
@@ -1,0 +1,43 @@
+package org.semagrow.plan.rel.sparql;
+
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.convert.ConverterRule;
+
+/**
+ * Created by angel on 13/7/2017.
+ */
+public class SparqlToSparqlConverterRule extends ConverterRule {
+
+    SparqlToSparqlConverterRule(SparqlConvention out, SparqlConvention in) {
+        super(SparqlRel.class, out, in,
+               "SPARQLtoSPARQLConverterRule");
+    }
+
+    @Override public RelNode convert(RelNode rel) {
+
+        SparqlConvention out = (SparqlConvention) getOutTrait();
+        SparqlConvention in  = (SparqlConvention) getInTrait();
+
+        RelTraitSet traits = rel.getTraitSet().replace(out);
+
+        if (out.getEndpoint().equals(in.getEndpoint()))
+        {
+            if (out.getDialect().isCompatible(in.getDialect()))
+                return rel.copy(traits, rel.getInputs());
+            else {
+                // NOTE: same endpoint but different SPARQL version.
+                // it is not safe (or is it?) to convert from SPARQL11 to SPARQL10 since rel may
+                // contain nodes only for SPARQL11.
+                return null;
+            }
+        } else {
+
+            if (out.getDialect().supportsFederatedQuery()) {
+                return new SparqlService(rel.getCluster(), traits, rel);
+            } else {
+                return null;
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlTupleExprRenderer.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlTupleExprRenderer.java
@@ -1,0 +1,297 @@
+package org.semagrow.plan.rel.sparql;
+
+import org.eclipse.rdf4j.query.algebra.*;
+import org.eclipse.rdf4j.queryrender.BaseTupleExprRenderer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * <p>
+ * Extends the BaseTupleExprRenderer to provide support for rendering tuple
+ * expressions as SPARQL queries.
+ * </p>
+ *
+ * @author Michael Grove
+ * @since 2.7.0
+ */
+public class SparqlTupleExprRenderer extends BaseTupleExprRenderer {
+
+    private StringBuffer mJoinBuffer = new StringBuffer();
+
+    private Map<TupleExpr, Var> mContexts = new HashMap<TupleExpr, Var>();
+
+    private int mIndent = 2;
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void reset() {
+        super.reset();
+
+        mJoinBuffer = new StringBuffer();
+        mContexts.clear();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public String render(final TupleExpr theExpr)
+            throws Exception
+    {
+        mContexts = ContextCollector.collectContexts(theExpr);
+
+        theExpr.visit(this);
+
+        return mJoinBuffer.toString();
+    }
+
+    private String indent() {
+        final StringBuilder aBuilder = new StringBuilder();
+        for (int i = 0; i < mIndent; i++) {
+            aBuilder.append(" ");
+        }
+        return aBuilder.toString();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected String renderValueExpr(final ValueExpr theExpr)
+            throws Exception
+    {
+        return new SparqlValueExprRenderer().render(theExpr);
+    }
+
+    private void ctxOpen(TupleExpr theExpr) {
+        Var aContext = mContexts.get(theExpr);
+
+        if (aContext != null) {
+            mJoinBuffer.append(indent()).append("GRAPH ");
+            if (aContext.hasValue()) {
+                mJoinBuffer.append(SparqlQueryStringUtil.toSPARQL(aContext.getValue()));
+            }
+            else {
+                mJoinBuffer.append("?").append(aContext.getName());
+            }
+            mJoinBuffer.append(" {\n");
+            mIndent += 2;
+        }
+    }
+
+    private void ctxClose(TupleExpr theExpr) {
+        Var aContext = mContexts.get(theExpr);
+
+        if (aContext != null) {
+            mJoinBuffer.append("}");
+            mIndent -= 2;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Join theJoin)
+            throws Exception
+    {
+        ctxOpen(theJoin);
+
+        theJoin.getLeftArg().visit(this);
+
+        theJoin.getRightArg().visit(this);
+
+        ctxClose(theJoin);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(LeftJoin theJoin)
+            throws Exception
+    {
+        ctxOpen(theJoin);
+
+        // try and reverse engineer the original scoping intent of the query
+        final boolean aNeedsNewScope = theJoin.getParentNode() != null
+                && (theJoin.getParentNode() instanceof Join || theJoin.getParentNode() instanceof LeftJoin);
+
+        if (aNeedsNewScope) {
+            mJoinBuffer.append("{\n");
+        }
+
+        theJoin.getLeftArg().visit(this);
+
+        mJoinBuffer.append(indent()).append("OPTIONAL {\n");
+
+        mIndent += 2;
+        theJoin.getRightArg().visit(this);
+
+        if (theJoin.getCondition() != null) {
+            mJoinBuffer.append(indent()).append("filter").append(renderValueExpr(theJoin.getCondition())).append(
+                    "\n");
+        }
+
+        mIndent -= 2;
+
+        mJoinBuffer.append(indent()).append("}.\n");
+
+        if (aNeedsNewScope) {
+            mJoinBuffer.append("}.\n");
+        }
+
+        ctxClose(theJoin);
+    }
+
+    /**
+     * Renders the tuple expression as a query string. It creates a new
+     * SparqlTupleExprRenderer rather than reusing this one.
+     *
+     * @param theExpr
+     *        the expr to render
+     * @return the rendered expression
+     * @throws Exception
+     *         if there is an error while rendering
+     */
+    private String renderTupleExpr(TupleExpr theExpr)
+            throws Exception
+    {
+        SparqlTupleExprRenderer aRenderer = new SparqlTupleExprRenderer();
+
+        // aRenderer.mProjection = new ArrayList<ProjectionElemList>(mProjection);
+        // aRenderer.mDistinct = mDistinct;
+        // aRenderer.mReduced = mReduced;
+        // aRenderer.mExtensions = new HashMap<String, ValueExpr>(mExtensions);
+        // aRenderer.mOrdering = new ArrayList<OrderElem>(mOrdering);
+        // aRenderer.mLimit = mLimit;
+        // aRenderer.mOffset = mOffset;
+
+        aRenderer.mIndent = mIndent;
+        aRenderer.mContexts = new HashMap<TupleExpr, Var>(mContexts);
+
+        return aRenderer.render(theExpr);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Union theOp)
+            throws Exception
+    {
+        ctxOpen(theOp);
+
+        String aLeft = renderTupleExpr(theOp.getLeftArg());
+        if (aLeft.endsWith("\n")) {
+            aLeft = aLeft.substring(0, aLeft.length() - 1);
+        }
+
+        String aRight = renderTupleExpr(theOp.getRightArg());
+        if (aRight.endsWith("\n")) {
+            aRight = aRight.substring(0, aRight.length() - 1);
+        }
+
+        mJoinBuffer.append(indent()).append("{\n").append(aLeft).append("\n").append(indent()).append("}\n").append(
+                indent()).append("union\n").append(indent()).append("{\n").append(aRight).append("\n").append(
+                indent()).append("}.\n");
+
+        ctxClose(theOp);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Difference theOp)
+            throws Exception
+    {
+        String aLeft = renderTupleExpr(theOp.getLeftArg());
+        String aRight = renderTupleExpr(theOp.getRightArg());
+
+        mJoinBuffer.append("\n{").append(aLeft).append("}").append("\nminus\n").append("{").append(aRight).append(
+                "}.\n");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Intersection theOp)
+            throws Exception
+    {
+        String aLeft = renderTupleExpr(theOp.getLeftArg());
+        String aRight = renderTupleExpr(theOp.getRightArg());
+
+        mJoinBuffer.append("\n").append(aLeft).append("}").append("\nintersection\n").append("{").append(aRight).append(
+                "}.\n");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(final Filter theFilter)
+            throws Exception
+    {
+        ctxOpen(theFilter);
+
+        if (theFilter.getArg() != null) {
+            theFilter.getArg().visit(this);
+        }
+
+        // try and reverse engineer the original scoping intent of the query
+        final boolean aNeedsNewScope = theFilter.getParentNode() != null
+                && (theFilter.getParentNode() instanceof Join || theFilter.getParentNode() instanceof LeftJoin);
+
+        String aFilter = renderValueExpr(theFilter.getCondition());
+        if (theFilter.getCondition() instanceof ValueConstant || theFilter.getCondition() instanceof Var) {
+            // means the filter is something like "filter (true)" or "filter (?v)"
+            // so we'll need to wrap it in parens since they can't live
+            // in the query w/o them, but we can't always wrap them in parens in
+            // the normal renderer
+
+            aFilter = "(" + aFilter + ")";
+        }
+
+        mJoinBuffer.append(indent());
+
+        // if (aNeedsNewScope) {
+        // mJoinBuffer.append("{ ");
+        // }
+
+        mJoinBuffer.append("filter ").append(aFilter).append(".");
+
+        // if (aNeedsNewScope) {
+        // mJoinBuffer.append("}.");
+        // }
+
+        mJoinBuffer.append("\n");
+
+        ctxClose(theFilter);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(StatementPattern thePattern)
+            throws Exception
+    {
+        ctxOpen(thePattern);
+
+        mJoinBuffer.append(indent()).append(renderPattern(thePattern));
+
+        ctxClose(thePattern);
+    }
+
+    String renderPattern(StatementPattern thePattern)
+            throws Exception
+    {
+        return renderValueExpr(thePattern.getSubjectVar()) + " "
+                + renderValueExpr(thePattern.getPredicateVar()) + " " + ""
+                + renderValueExpr(thePattern.getObjectVar()) + ".\n";
+
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlValueExprRenderer.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlValueExprRenderer.java
@@ -1,0 +1,464 @@
+package org.semagrow.plan.rel.sparql;
+
+import org.eclipse.rdf4j.query.algebra.*;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
+import org.eclipse.rdf4j.queryrender.BaseTupleExprRenderer;
+
+/**
+ * <p>
+ * Renders a Sesame {@link ValueExpr} into SPARQL syntax.
+ * </p>
+ *
+ * @author Michael Grove
+ * @since 2.7.0
+ */
+final class SparqlValueExprRenderer extends AbstractQueryModelVisitor<Exception> {
+
+    /**
+     * The current rendered value
+     */
+    private StringBuffer mBuffer = new StringBuffer();
+
+    /**
+     * Reset the state of this renderer
+     */
+    public void reset() {
+        mBuffer = new StringBuffer();
+    }
+
+    /**
+     * Return the rendering of the ValueExpr object
+     *
+     * @param theExpr
+     *        the expression to render
+     * @return the rendering
+     * @throws Exception
+     *         if there is an error while rendering
+     */
+    public String render(ValueExpr theExpr)
+            throws Exception
+    {
+        theExpr.visit(this);
+
+        return mBuffer.toString();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Bound theOp)
+            throws Exception
+    {
+        mBuffer.append(" bound(");
+        theOp.getArg().visit(this);
+        mBuffer.append(")");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Var theVar)
+            throws Exception
+    {
+        if (theVar.isAnonymous() && !theVar.hasValue()) {
+            mBuffer.append("?").append(BaseTupleExprRenderer.scrubVarName(theVar.getName()));
+        }
+        else if (theVar.hasValue()) {
+            mBuffer.append(SparqlQueryStringUtil.toSPARQL(theVar.getValue()));
+        }
+        else {
+            mBuffer.append("?").append(theVar.getName());
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(BNodeGenerator theGen)
+            throws Exception
+    {
+        mBuffer.append(theGen.getSignature());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(MathExpr theOp)
+            throws Exception
+    {
+        mBuffer.append("(");
+        theOp.getLeftArg().visit(this);
+        mBuffer.append(" ").append(theOp.getOperator().getSymbol()).append(" ");
+        theOp.getRightArg().visit(this);
+        mBuffer.append(")");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Compare theOp)
+            throws Exception
+    {
+        mBuffer.append("(");
+        theOp.getLeftArg().visit(this);
+        mBuffer.append(" ").append(theOp.getOperator().getSymbol()).append(" ");
+        theOp.getRightArg().visit(this);
+        mBuffer.append(")");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Exists theOp)
+            throws Exception
+    {
+        mBuffer.append(" exists(");
+        mBuffer.append(renderTupleExpr(theOp.getSubQuery()));
+        mBuffer.append(")");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(In theOp)
+            throws Exception
+    {
+        theOp.getArg().visit(this);
+        mBuffer.append(" in ");
+        mBuffer.append("(");
+        mBuffer.append(renderTupleExpr(theOp.getSubQuery()));
+        mBuffer.append(")");
+    }
+
+    /**
+     * Renders the tuple expression as a query string.
+     *
+     * @param theExpr
+     *        the expr to render
+     * @return the rendered expression
+     * @throws Exception
+     *         if there is an error while rendering
+     */
+    private String renderTupleExpr(TupleExpr theExpr)
+            throws Exception
+    {
+        SparqlTupleExprRenderer aRenderer = new SparqlTupleExprRenderer();
+        return aRenderer.render(theExpr);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(CompareAll theOp)
+            throws Exception
+    {
+        mBuffer.append("(");
+        theOp.getArg().visit(this);
+        mBuffer.append(" ").append(theOp.getOperator().getSymbol()).append(" all ");
+        mBuffer.append("(");
+        mBuffer.append(renderTupleExpr(theOp.getSubQuery()));
+        mBuffer.append(")");
+        mBuffer.append(")");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(ValueConstant theVal)
+            throws Exception
+    {
+        mBuffer.append(SparqlQueryStringUtil.toSPARQL(theVal.getValue()));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(FunctionCall theOp)
+            throws Exception
+    {
+        mBuffer.append("<").append(theOp.getURI()).append(">(");
+        boolean aFirst = true;
+        for (ValueExpr aArg : theOp.getArgs()) {
+            if (!aFirst) {
+                mBuffer.append(", ");
+            }
+            else {
+                aFirst = false;
+            }
+
+            aArg.visit(this);
+        }
+        mBuffer.append(")");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(CompareAny theOp)
+            throws Exception
+    {
+        mBuffer.append("(");
+        theOp.getArg().visit(this);
+        mBuffer.append(" ").append(theOp.getOperator().getSymbol()).append(" any ");
+        mBuffer.append("(");
+        mBuffer.append(renderTupleExpr(theOp.getSubQuery()));
+        mBuffer.append(")");
+        mBuffer.append(")");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Regex theOp)
+            throws Exception
+    {
+        mBuffer.append(" regex(");
+        theOp.getArg().visit(this);
+        mBuffer.append(", ");
+        theOp.getPatternArg().visit(this);
+        if (theOp.getFlagsArg() != null) {
+            mBuffer.append(",");
+            theOp.getFlagsArg().visit(this);
+        }
+        mBuffer.append(")");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(LangMatches theOp)
+            throws Exception
+    {
+        mBuffer.append(" langMatches(");
+        theOp.getLeftArg().visit(this);
+        mBuffer.append(", ");
+        theOp.getRightArg().visit(this);
+        mBuffer.append(")");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(SameTerm theOp)
+            throws Exception
+    {
+        mBuffer.append(" sameTerm(");
+        theOp.getLeftArg().visit(this);
+        mBuffer.append(", ");
+        theOp.getRightArg().visit(this);
+        mBuffer.append(")");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(And theAnd)
+            throws Exception
+    {
+        binaryMeet("&&", theAnd);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Or theOr)
+            throws Exception
+    {
+        binaryMeet("||", theOr);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Not theNot)
+            throws Exception
+    {
+        mBuffer.append("(");
+        unaryMeet("!", theNot);
+        mBuffer.append(")");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Count theOp)
+            throws Exception
+    {
+        unaryMeet("count", theOp);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Datatype theOp)
+            throws Exception
+    {
+        unaryMeet("datatype", theOp);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(IsBNode theOp)
+            throws Exception
+    {
+        unaryMeet("isBlank", theOp);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(IsLiteral theOp)
+            throws Exception
+    {
+        unaryMeet("isLiteral", theOp);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(IsResource theOp)
+            throws Exception
+    {
+        // there's no isResource method in SPARQL, so lets serialize this as not
+        // isLiteral -- if something is not a literal
+        // then its probably a resource, tho it might be just not bound so this
+        // might not be 100% correct,
+        // but close enough for right now.
+        unaryMeet("!isLiteral", theOp);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(IsURI theOp)
+            throws Exception
+    {
+        unaryMeet("isURI", theOp);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Label theOp)
+            throws Exception
+    {
+        unaryMeet("label", theOp);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Lang theOp)
+            throws Exception
+    {
+        unaryMeet("lang", theOp);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Like theOp)
+            throws Exception
+    {
+        theOp.getArg().visit(this);
+        mBuffer.append(" like \"").append(theOp.getPattern()).append("\"");
+        if (!theOp.isCaseSensitive()) {
+            mBuffer.append(" ignore case");
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(LocalName theOp)
+            throws Exception
+    {
+        unaryMeet("localName", theOp);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Min theOp)
+            throws Exception
+    {
+        unaryMeet("min", theOp);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Max theOp)
+            throws Exception
+    {
+        unaryMeet("max", theOp);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Namespace theOp)
+            throws Exception
+    {
+        unaryMeet("namespace", theOp);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void meet(Str theOp)
+            throws Exception
+    {
+        unaryMeet("str", theOp);
+    }
+
+    private void binaryMeet(String theOpStr, BinaryValueOperator theOp)
+            throws Exception
+    {
+        mBuffer.append(" (");
+        theOp.getLeftArg().visit(this);
+        mBuffer.append(" ").append(theOpStr).append(" ");
+        theOp.getRightArg().visit(this);
+        mBuffer.append(")");
+    }
+
+    private void unaryMeet(String theOpStr, UnaryValueOperator theOp)
+            throws Exception
+    {
+        mBuffer.append(" ").append(theOpStr).append("(");
+        theOp.getArg().visit(this);
+        mBuffer.append(")");
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlVersion.java
+++ b/core/src/main/java/org/semagrow/plan/rel/sparql/SparqlVersion.java
@@ -1,0 +1,29 @@
+package org.semagrow.plan.rel.sparql;
+
+
+public enum SparqlVersion implements Comparable<SparqlVersion> {
+
+    SPARQL10(1,0),
+    SPARQL11(1,1);
+
+    private int major;
+    private int minor;
+
+    SparqlVersion(int major, int minor) {
+        this.major = major;
+        this.minor = minor;
+    }
+
+    public boolean isBackwardsCompatible(SparqlVersion that)  {
+        return this.major == that.major && this.minor >= that.minor;
+    }
+
+    @Override
+    public String toString() {
+        if (major == 1 && minor == 0)
+            return "SPARQL";
+        else
+            return "SPARQL" + major + "." + minor;
+    }
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/type/AbstractRdfType.java
+++ b/core/src/main/java/org/semagrow/plan/rel/type/AbstractRdfType.java
@@ -1,0 +1,10 @@
+package org.semagrow.plan.rel.type;
+
+import org.apache.calcite.rel.type.RelDataTypeImpl;
+
+/**
+ * Created by angel on 7/7/2017.
+ */
+public abstract class AbstractRdfType extends RelDataTypeImpl {
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/type/BasicRdfType.java
+++ b/core/src/main/java/org/semagrow/plan/rel/type/BasicRdfType.java
@@ -1,0 +1,31 @@
+package org.semagrow.plan.rel.type;
+
+import org.apache.calcite.sql.SqlCollation;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+import java.nio.charset.Charset;
+
+/**
+ * Created by angel on 7/7/2017.
+ */
+public class BasicRdfType extends AbstractRdfType {
+
+
+    private final String name;
+
+    public BasicRdfType(String name) { this.name = name; computeDigest(); }
+
+    @Override
+    protected void generateTypeString(StringBuilder sb, boolean withDetail) {
+        sb.append(name);
+    }
+
+    @Override
+    public SqlTypeName getSqlTypeName() { return SqlTypeName.CHAR; }
+
+    @Override
+    public SqlCollation getCollation() { return SqlCollation.COERCIBLE; }
+
+    @Override
+    public Charset getCharset() { return Charset.forName("ISO-8859-1"); }
+}

--- a/core/src/main/java/org/semagrow/plan/rel/type/RDFTypes.java
+++ b/core/src/main/java/org/semagrow/plan/rel/type/RDFTypes.java
@@ -1,0 +1,15 @@
+package org.semagrow.plan.rel.type;
+
+import org.apache.calcite.rel.type.RelDataType;
+
+/**
+ * Created by angel on 7/7/2017.
+ */
+public class RDFTypes {
+
+    static public RelDataType PLAIN_LITERAL = new BasicRdfType("RDF PLAIN LITERAL");
+
+    static public RelDataType IRI_TYPE   = new BasicRdfType("RDF IRI");
+    static public RelDataType BLANK_NODE = new BasicRdfType("RDF BLANK NODE");
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/type/RdfDataTypeFactory.java
+++ b/core/src/main/java/org/semagrow/plan/rel/type/RdfDataTypeFactory.java
@@ -1,0 +1,12 @@
+package org.semagrow.plan.rel.type;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.eclipse.rdf4j.model.IRI;
+
+
+public interface RdfDataTypeFactory extends RelDataTypeFactory {
+
+    RelDataType createRdfDataType(IRI datatypeIRI);
+
+}

--- a/core/src/main/java/org/semagrow/plan/rel/type/RdfDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/semagrow/plan/rel/type/RdfDataTypeFactoryImpl.java
@@ -1,0 +1,69 @@
+package org.semagrow.plan.rel.type;
+
+import com.google.common.base.Preconditions;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class RdfDataTypeFactoryImpl
+        extends SqlTypeFactoryImpl
+        implements RdfDataTypeFactory
+{
+
+    public RdfDataTypeFactoryImpl(RelDataTypeSystem typeSystem) {
+        super(typeSystem);
+    }
+
+    @Override
+    public RelDataType createRdfDataType(IRI dataType) {
+        RdfDataType type = new RdfDataType(dataType);
+        return canonize(type);
+    }
+
+    /**
+     * Created by angel on 7/7/2017.
+     */
+    protected static class RdfDataType extends AbstractRdfType {
+
+        private IRI datatype;
+
+        static Map<IRI, SqlTypeName> dataTypetoSQL = new HashMap<>();
+
+        static {
+            dataTypetoSQL.put(XMLSchema.BOOLEAN, SqlTypeName.BOOLEAN);
+            dataTypetoSQL.put(XMLSchema.INTEGER, SqlTypeName.DECIMAL);
+            dataTypetoSQL.put(XMLSchema.INT, SqlTypeName.DECIMAL);
+            dataTypetoSQL.put(XMLSchema.SHORT, SqlTypeName.DECIMAL);
+            dataTypetoSQL.put(XMLSchema.LONG, SqlTypeName.DECIMAL);
+            dataTypetoSQL.put(XMLSchema.DECIMAL, SqlTypeName.DECIMAL);
+            dataTypetoSQL.put(XMLSchema.DOUBLE, SqlTypeName.DOUBLE);
+            dataTypetoSQL.put(XMLSchema.DATE, SqlTypeName.DATE);
+            dataTypetoSQL.put(XMLSchema.BASE64BINARY, SqlTypeName.BINARY);
+            dataTypetoSQL.put(XMLSchema.STRING, SqlTypeName.CHAR);
+        }
+
+        public RdfDataType(IRI datatype) {
+            this.datatype = Preconditions.checkNotNull(datatype);
+            computeDigest();
+        }
+
+        @Override
+        protected void generateTypeString(StringBuilder sb, boolean withDetail) {
+            sb.append(datatype.toString());
+        }
+
+        @Override
+        public SqlTypeName getSqlTypeName() {
+            return dataTypetoSQL.get(datatype);
+        }
+
+
+    }
+}

--- a/core/src/test/java/org/semagrow/plan/rel/TransformTest.java
+++ b/core/src/test/java/org/semagrow/plan/rel/TransformTest.java
@@ -1,0 +1,157 @@
+package org.semagrow.plan.rel;
+
+import com.google.common.collect.ImmutableList;
+import junit.framework.TestCase;
+import org.apache.calcite.plan.*;
+import org.apache.calcite.plan.hep.HepProgram;
+import org.apache.calcite.plan.volcano.VolcanoPlanner;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.rel.rules.FilterJoinRule;
+import org.apache.calcite.rel.rules.ProjectMergeRule;
+import org.apache.calcite.rel.rules.SubQueryRemoveRule;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.sql.SqlExplainLevel;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.tools.Program;
+import org.apache.calcite.tools.Programs;
+import org.eclipse.rdf4j.query.algebra.QueryRoot;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser;
+import org.junit.Test;
+import org.semagrow.plan.rel.rules.StatementScanRule;
+import org.semagrow.plan.rel.semagrow.SemagrowConvention;
+import org.semagrow.plan.rel.semagrow.SemagrowRel;
+import org.semagrow.plan.rel.semagrow.SemagrowRules;
+import org.semagrow.plan.rel.type.RdfDataTypeFactoryImpl;
+
+/**
+ * Created by antonis on 6/7/2017.
+ */
+public class TransformTest extends TestCase {
+
+    private String q1 = "" +
+            "SELECT DISTINCT ?party ?page  WHERE {\n" +
+            "   <http://dbpedia.org/resource/Barack_Obama> <http://dbpedia.org/ontology/party> ?party .\n" +
+            "   ?x <http://data.nytimes.com/elements/topicPage> ?page .\n" +
+            "   ?x <http://www.w3.org/2002/07/owl#sameAs> <http://dbpedia.org/resource/Barack_Obama> .\n" +
+            "}";
+
+    private String q2 = "" +
+            "SELECT ?predicate ?object WHERE {\n" +
+            "   { <http://dbpedia.org/resource/Barack_Obama> ?predicate ?object }\n" +
+            "   UNION  {  \n" +
+            "      ?subject <http://www.w3.org/2002/07/owl#sameAs> <http://dbpedia.org/resource/Barack_Obama> .\n" +
+            "     ?subject ?predicate ?object } \n" +
+            "}";
+
+    private String q3 = "" +
+            "SELECT $drug $transform $mass WHERE {  \n" +
+            "  { $drug <http://www4.wiwiss.fu-berlin.de/drugbank/resource/drugbank/affectedOrganism>  'Humans and other mammals'.\n" +
+            "    $drug <http://www4.wiwiss.fu-berlin.de/drugbank/resource/drugbank/casRegistryNumber> $cas .\n" +
+            "    $keggDrug <http://bio2rdf.org/ns/bio2rdf#xRef> $cas .\n" +
+            "    $keggDrug <http://bio2rdf.org/ns/bio2rdf#mass> $mass\n" +
+            "    FILTER ( $mass > 5 )\n" +
+            "  } \n" +
+            "  OPTIONAL { $drug <http://www4.wiwiss.fu-berlin.de/drugbank/resource/drugbank/biotransformation> $transform . " +
+            " FILTER ($transform > 4)" +
+            "} \n" +
+            "}";
+
+
+    private String q4 = "" +
+            "SELECT $drug $cas (COUNT($drug) AS ?c) WHERE   \n" +
+            "  { $drug <http://www4.wiwiss.fu-berlin.de/drugbank/resource/drugbank/affectedOrganism>  'Humans and other mammals'.\n" +
+            "    $drug <http://www4.wiwiss.fu-berlin.de/drugbank/resource/drugbank/casRegistryNumber> $cas .\n" +
+            "    $keggDrug <http://bio2rdf.org/ns/bio2rdf#xRef> $cas .\n" +
+            "    $keggDrug <http://bio2rdf.org/ns/bio2rdf#mass> $mass\n" +
+            "    FILTER ( $mass > '5' )\n" +
+            "  } \n"+
+            "  GROUP BY $drug $cas \n" +
+            "";
+
+
+    private String q5 = "" +
+            "SELECT $drug WHERE   \n" +
+            "  { $drug <http://www4.wiwiss.fu-berlin.de/drugbank/resource/drugbank/affectedOrganism>  'Humans and other mammals'.\n" +
+            "    $drug <http://www4.wiwiss.fu-berlin.de/drugbank/resource/drugbank/casRegistryNumber> $cas .\n" +
+            "    $keggDrug <http://bio2rdf.org/ns/bio2rdf#xRef> $cas .\n" +
+            "    $keggDrug <http://bio2rdf.org/ns/bio2rdf#mass> $mass\n" +
+            "    FILTER ( $mass > '5' || $mass < 2)." +
+            "    FILTER EXISTS { SELECT $cas1 { $drug1 <http://www4.wiwiss.fu-berlin.de/drugbank/resource/drugbank/casRegistryNumber> $cas1 ." +
+            "                     FILTER ($drug = $drug1) }}\n" +
+            "  } \n";
+
+    private String q6 = "" +
+            "PREFIX movie: <http://data.linkedmdb.org/resource/movie/>\n" +
+            "PREFIX dc: <http://purl.org/dc/terms/>\n" +
+            "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> \n" +
+            "SELECT ?a " +
+            "(?title as ?titel) \n" +
+            " (xsd:float(?runtimeStr) as ?runtime)\n" +
+            //" (xsd:int(substr(?dateStr,1,4)) as ?year) \n" +
+            "WHERE {\n" +
+            " ?a a movie:film.\n" +
+            " ?a movie:runtime ?runtimeStr.\n" +
+            " ?a dc:title ?title.\n" +
+            " ?a dc:date ?dateStr.\n" +
+            "}";
+
+    @Test
+    public void testTransformSimple() {
+
+        VolcanoPlanner planner = new VolcanoPlanner();
+        planner.addRelTraitDef(ConventionTraitDef.INSTANCE);
+
+        RelOptCluster cluster = RelOptCluster.create(
+                planner,
+                new RdfRexBuilder(new RdfDataTypeFactoryImpl(RelDataTypeSystem.DEFAULT))
+        );
+        TupleExprToRelConverter tupleExprToRelConverter = new TupleExprToRelConverter(cluster, CatalogReader.INSTANCE);
+        RelToTupleExprConverter relToTupleExprConverter = new RelToTupleExprConverter();
+        SPARQLParser parser = new SPARQLParser();
+
+        String queries[] = {
+                //q1
+                q2,
+                //q4,
+                //q6
+        };
+
+        for (String queryString: queries) {
+            TupleExpr expr = parser.parseQuery(queryString, null).getTupleExpr();
+            QueryRoot sparqlroot = new QueryRoot(expr);
+            RelRoot relroot = tupleExprToRelConverter.convertQuery(sparqlroot);
+            RelNode rel = relroot.rel;
+
+            HepProgram hepProgram = HepProgram.builder()
+                    .addRuleInstance(SubQueryRemoveRule.FILTER)
+                    .addRuleInstance(SubQueryRemoveRule.JOIN)
+                    .addRuleInstance(SubQueryRemoveRule.PROJECT)
+                    .addRuleInstance(ProjectMergeRule.INSTANCE)
+                    .addRuleInstance(StatementScanRule.INSTANCE)
+                    .build();
+
+            Program p  = Programs.of(hepProgram, false, null);
+
+            rel = p.run(cluster.getPlanner(), rel, null, ImmutableList.of(), ImmutableList.of());
+            System.out.println(RelOptUtil.dumpPlan("", rel, false, SqlExplainLevel.ALL_ATTRIBUTES));
+
+            //p = Programs.ofRules(FilterJoinRule.FILTER_ON_JOIN);
+            p = Programs.ofRules(SemagrowRules.RULES);
+            rel = p.run(cluster.getPlanner(),
+                    rel,
+                    cluster.traitSet().replace(SemagrowConvention.INSTANCE),
+                    ImmutableList.of(),
+                    ImmutableList.of());
+
+            System.out.println(sparqlroot);
+            System.out.println(RelOptUtil.dumpPlan("", rel, false, SqlExplainLevel.ALL_ATTRIBUTES));
+
+            //TupleExpr sparqlnew = relToTupleExprConverter.convertQuery(RelRoot.of(rel, SqlKind.SELECT));
+            //System.out.println(sparqlnew);
+        }
+    }
+}


### PR DESCRIPTION
[Apache Calcite](https://calcite.apache.org/) features a rule-based optimizer of Relational Algebra.  The core idea of the optimizer is to search alternative execution plans by applying transformation rules to the current "best" plan. We argue that semagrow will benefit from a rule-based optimizer in several ways:
- If the optimizer is configured to stop at an arbitrary step the resulting execution plan is valid.
- Rules can be asserted or retracted on demand and new operators can be included to the optimizer in an extensible way. This fits naturally to the extensible nature of semagrow that aims to support different underlying sources.

