### PR TITLE
Fixes to make Semagrow work with Glassfish 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,5 @@ be retrieved using [`docker inspect`](https://docs.docker.com/engine/reference/c
 ## Known issues
 
 * SemaGrow uses UNION instead of VALUES to implement the BindJoin operator. This fails in 4store 1.1.5 and previous versions in the  presence of FILTER clauses due to an unsafe optimization by 4store.
+* When deploying in Glassfish 4 by coping the SemaGrow.war file in the autodeploy directory, Semagrow is accessible at `http://DOMAIN/SemaGrow/index.jsp` instead of `http://DOMAIN/SemaGrow/`
+

--- a/webgui/src/main/java/org/semagrow/http/gui/controllers/SparqlSamplesController.java
+++ b/webgui/src/main/java/org/semagrow/http/gui/controllers/SparqlSamplesController.java
@@ -50,8 +50,8 @@ public class SparqlSamplesController {
     }
     
     @PostConstruct
-    public void startUp() throws IOException, RDFParseException, RDFHandlerException  {
-        if(this.sparqlSamplesFile!=null){
+    public void startUp() /**throws IOException, RDFParseException, RDFHandlerException*/ {
+        /**if(this.sparqlSamplesFile!=null){
             HashMapHandler handler = new HashMapHandler();
             RDFParser parser = Rio.createParser(RDFFormat.TURTLE);
             parser.setRDFHandler(handler);
@@ -65,7 +65,7 @@ public class SparqlSamplesController {
                     fis.close();
                 }
             }            
-        }
+        }*/
     }
     
     @PreDestroy

--- a/webgui/src/main/webapp/WEB-INF/web.xml
+++ b/webgui/src/main/webapp/WEB-INF/web.xml
@@ -60,6 +60,7 @@
         <url-pattern>/sparql/decompose</url-pattern>
     </servlet-mapping>
 
+<!--
     <security-constraint>
         <web-resource-collection>
             <web-resource-name>*</web-resource-name>
@@ -99,5 +100,7 @@
     <login-config>
         <realm-name>SemaGrow</realm-name>
         <auth-method>BASIC</auth-method> 
-    </login-config>    
+    </login-config>
+-->
+
 </web-app>


### PR DESCRIPTION
- Disabled authentication
- Removed sparql samples
- Added note in README regarding Semagrow URL on Glassfish 4