### PR TITLE
Change travis dist to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 sudo: false
 jdk: oraclejdk8


### PR DESCRIPTION
Travis [now](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment) uses `xenial` as the default build environment which causes our pipeline to fail since java8 is not supported. Move back to `trusty` to resolve this.