### PR TITLE
Feat geospatial selector

### DIFF
--- a/core/src/main/java/org/semagrow/evaluation/reactor/EvaluationStrategyImpl.java
+++ b/core/src/main/java/org/semagrow/evaluation/reactor/EvaluationStrategyImpl.java
@@ -282,7 +282,7 @@ public class EvaluationStrategyImpl implements EvaluationStrategy {
     public Flux<BindingSet> evaluateReactorInternal(Union expr, BindingSet bindings)
             throws QueryEvaluationException
     {
-        return Flux.concat(
+        return Flux.merge(
                 this.evaluateReactorInternal(expr.getLeftArg(), bindings),
                 this.evaluateReactorInternal(expr.getRightArg(), bindings));
     }

--- a/core/src/main/java/org/semagrow/plan/SimpleQueryCompiler.java
+++ b/core/src/main/java/org/semagrow/plan/SimpleQueryCompiler.java
@@ -63,7 +63,7 @@ public class SimpleQueryCompiler implements QueryCompiler {
         plans = getContext().enforceProps(plans, props);
         getContext().prune(plans);
 
-        Plan plan = (plans.isEmpty()) ? null : plans.iterator().next();
+        Plan plan = (plans.isEmpty()) ? new Plan(new EmptySet()) : plans.iterator().next();
 
         optimize(plan, dataset, bindings);
 

--- a/core/src/main/java/org/semagrow/plan/SimpleQueryCompiler.java
+++ b/core/src/main/java/org/semagrow/plan/SimpleQueryCompiler.java
@@ -9,9 +9,8 @@ import org.eclipse.rdf4j.query.algebra.evaluation.impl.*;
 import org.eclipse.rdf4j.query.algebra.evaluation.util.QueryOptimizerList;
 import org.semagrow.estimator.CardinalityEstimatorResolver;
 import org.semagrow.estimator.CostEstimatorResolver;
-import org.semagrow.estimator.SimpleCardinalityEstimatorResolver;
-import org.semagrow.estimator.SimpleCostEstimatorResolver;
 import org.semagrow.local.LocalSite;
+import org.semagrow.plan.optimizer.FilterPlanOptimizer;
 import org.semagrow.plan.queryblock.*;
 import org.semagrow.selector.QueryAwareSourceSelector;
 import org.semagrow.selector.SourceSelector;
@@ -64,10 +63,11 @@ public class SimpleQueryCompiler implements QueryCompiler {
         plans = getContext().enforceProps(plans, props);
         getContext().prune(plans);
 
-        if (plans.isEmpty())
-            return null;
-        else
-            return plans.iterator().next();
+        Plan plan = (plans.isEmpty()) ? null : plans.iterator().next();
+
+        optimize(plan, dataset, bindings);
+
+        return plan;
     }
 
     private QueryBlock blockify(QueryRoot query, Dataset dataset, BindingSet bindings) {
@@ -98,6 +98,15 @@ public class SimpleQueryCompiler implements QueryCompiler {
                 new DisjunctiveConstraintOptimizer(),   // split Filters Or to Union
                 new FilterOptimizer(),                  // push Filters as deep as possible
                 new QueryModelNormalizer()              // remove emptysets, singletonsets, transform to DNF (union before joins)
+        );
+
+        queryOptimizer.optimize(expr, dataset, bindings);
+    }
+
+    protected void optimize(TupleExpr expr, Dataset dataset, BindingSet bindings) {
+
+        QueryOptimizer queryOptimizer =  new QueryOptimizerList(
+                new FilterPlanOptimizer()
         );
 
         queryOptimizer.optimize(expr, dataset, bindings);

--- a/core/src/main/java/org/semagrow/plan/optimizer/FilterPlanOptimizer.java
+++ b/core/src/main/java/org/semagrow/plan/optimizer/FilterPlanOptimizer.java
@@ -1,0 +1,80 @@
+package org.semagrow.plan.optimizer;
+
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.algebra.*;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
+import org.semagrow.plan.AbstractPlanVisitor;
+import org.semagrow.plan.Plan;
+import org.semagrow.plan.operators.SourceQuery;
+
+public class FilterPlanOptimizer implements QueryOptimizer {
+
+    public void optimize(TupleExpr tupleExpr, Dataset dataset, BindingSet bindings) {
+        tupleExpr.visit(new FilterFinder(tupleExpr));
+    }
+
+    protected static class FilterFinder extends AbstractPlanVisitor<RuntimeException> {
+        protected final TupleExpr tupleExpr;
+
+        public FilterFinder(TupleExpr tupleExpr) {
+            this.tupleExpr = tupleExpr;
+        }
+
+        public void meet(Filter filter) {
+            super.meet(filter);
+            FilterOptimizer.FilterRelocator.relocate(filter);
+        }
+    }
+
+    protected static class FilterRelocator extends AbstractPlanVisitor<RuntimeException> {
+        protected final Filter filter;
+
+        public static void relocate(Filter filter) {
+            filter.visit(new FilterPlanOptimizer.FilterRelocator(filter));
+        }
+
+        public FilterRelocator(Filter filter) {
+            this.filter = filter;
+        }
+
+        protected void meetNode(QueryModelNode node) {
+            assert node instanceof TupleExpr;
+
+            this.relocate(this.filter, (TupleExpr)node);
+        }
+
+        public void meet(Plan plan) {
+            plan.getArg().visit(this);
+        }
+
+        public void meet(Union union) {
+            Filter clone = new Filter();
+            clone.setCondition(this.filter.getCondition().clone());
+            this.relocate(this.filter, union.getLeftArg());
+            this.relocate(clone, union.getRightArg());
+            relocate(this.filter);
+            relocate(clone);
+        }
+
+        public void meet(SourceQuery sourceQuery) {
+            this.relocate(this.filter, sourceQuery.getArg());
+        }
+
+        public void meet(Filter filter) {
+            filter.getArg().visit(this);
+        }
+
+        protected void relocate(Filter filter, TupleExpr newFilterArg) {
+            if (filter.getArg() != newFilterArg) {
+                if (filter.getParentNode() != null) {
+                    filter.replaceWith(filter.getArg());
+                }
+
+                newFilterArg.replaceWith(filter);
+                filter.setArg(newFilterArg);
+            }
+
+        }
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/optimizer/FilterPlanOptimizer.java
+++ b/core/src/main/java/org/semagrow/plan/optimizer/FilterPlanOptimizer.java
@@ -23,7 +23,7 @@ public class FilterPlanOptimizer implements QueryOptimizer {
 
         public void meet(Filter filter) {
             super.meet(filter);
-            FilterOptimizer.FilterRelocator.relocate(filter);
+            FilterRelocator.relocate(filter);
         }
     }
 

--- a/core/src/main/java/org/semagrow/selector/PrefixQueryAwareSourceSelector.java
+++ b/core/src/main/java/org/semagrow/selector/PrefixQueryAwareSourceSelector.java
@@ -29,6 +29,9 @@ public class PrefixQueryAwareSourceSelector extends SourceSelectorWrapper implem
 
     @Override
     public void processTupleExpr(TupleExpr expr) {
+        if (getWrappedSelector() instanceof QueryAwareSourceSelector) {
+            ((QueryAwareSourceSelector) getWrappedSelector()).processTupleExpr(expr);
+        }
         Collection<TupleExpr> bpgs = BPGCollector.process(expr);
         for (TupleExpr bpg: bpgs) {
             processBPG(bpg);

--- a/geospatial/pom.xml
+++ b/geospatial/pom.xml
@@ -13,6 +13,10 @@
     <artifactId>semagrow-geospatial</artifactId>
     <packaging>jar</packaging>
 
+    <properties>
+        <semagrow.version>${project.version}</semagrow.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
@@ -29,6 +33,12 @@
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-queryalgebra-geosparql</artifactId>
             <version>${rdf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.semagrow</groupId>
+            <artifactId>semagrow-core</artifactId>
+            <version>${semagrow.version}</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/geospatial/src/main/java/org/semagrow/geospatial/helpers/WktHelpers.java
+++ b/geospatial/src/main/java/org/semagrow/geospatial/helpers/WktHelpers.java
@@ -1,0 +1,78 @@
+package org.semagrow.geospatial.helpers;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.GEO;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+import org.locationtech.jts.io.WKTWriter;
+
+public final class WktHelpers {
+
+    private static WKTReader wktReader;
+    private static WKTWriter wktWriter;
+
+    private static ValueFactory vf;
+
+    static {
+        wktReader = new WKTReader();
+        wktWriter = new WKTWriter();
+        vf = SimpleValueFactory.getInstance();
+    }
+
+    public static final IRI getCRS(Literal l) {
+        assert l.getDatatype().equals(GEO.WKT_LITERAL);
+
+        String str = l.stringValue();
+
+        if (str.startsWith("<")) {
+            int n = str.indexOf(">");
+            return vf.createIRI(str.substring(1,n));
+        }
+        else {
+            return vf.createIRI(GEO.DEFAULT_SRID);
+        }
+    }
+
+    public static final Geometry createGeometry(Literal l, IRI crs) throws ParseException {
+        assert l.getDatatype().equals(GEO.WKT_LITERAL);
+        String str = l.stringValue();
+
+        if (str.startsWith("<")) {
+            if (getCRS(l).equals(crs)) {
+                int n = str.indexOf(">") + 2;
+                return wktReader.read(str.substring(n));
+            }
+        }
+        else {
+            if (crs.equals(GEO.DEFAULT_SRID)) {
+                return wktReader.read(str);
+            }
+        }
+        throw new ParseException("Non matching CRS");
+    }
+
+
+    public static final Literal createWKTLiteral(Geometry geometry, IRI crs) {
+
+        String wktStr = wktWriter.write(geometry);
+        String crsStr = crs.equals(GEO.DEFAULT_SRID) ? "" : "<" + crs.toString() + "> ";
+        Literal l = vf.createLiteral(crsStr + wktStr, GEO.WKT_LITERAL);
+
+        return l;
+    }
+
+    public static final Literal removeCRSfromWKT(Literal l) {
+        if (l.getDatatype().equals(GEO.WKT_LITERAL)) {
+            String str = l.stringValue();
+            if (str.startsWith("<")) {
+                int n = str.indexOf(">") + 2;
+                return vf.createLiteral(str.substring(n), l.getDatatype());
+            }
+        }
+        return l;
+    }
+}

--- a/geospatial/src/main/java/org/semagrow/geospatial/selector/BoundingBoxBase.java
+++ b/geospatial/src/main/java/org/semagrow/geospatial/selector/BoundingBoxBase.java
@@ -1,0 +1,65 @@
+package org.semagrow.geospatial.selector;
+
+import org.eclipse.rdf4j.model.*;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
+import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
+import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries;
+import org.eclipse.rdf4j.sparqlbuilder.core.query.SelectQuery;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
+import org.semagrow.geospatial.vocabulary.SEVOD_GEO;
+import org.semagrow.model.vocabulary.VOID;
+
+public class BoundingBoxBase {
+
+    private Repository metadata;
+
+    public void setMetadata(Repository metadata) {
+        this.metadata = metadata;
+    }
+
+    public Literal getDatasetBoundingBox(Resource endpoint) {
+
+        Variable dataset = SparqlBuilder.var("dataset");
+        Variable mbb = SparqlBuilder.var("mbb");
+
+        TriplePattern t1 = dataset.has(RDF.TYPE, VOID.DATASET);
+        TriplePattern t2 = dataset.has(VOID.SPARQLENDPOINT, endpoint);
+        TriplePattern t3 = dataset.has(SEVOD_GEO.DATASET_BOUNDING_BOX, mbb);
+
+        GraphPattern body = GraphPatterns.and(t1,t2,t3);
+        SelectQuery selectQuery = Queries.SELECT().select(mbb).where(body);
+
+        Value wktLiteral = runQuery("mbb", selectQuery.getQueryString());
+
+        if (wktLiteral != null) {
+            return (Literal) wktLiteral;
+        }
+        return null;
+    }
+
+    private Value runQuery(String varName, String qStr){
+        RepositoryConnection conn = null;
+        try {
+            conn = metadata.getConnection();
+            TupleQuery q = conn.prepareTupleQuery(QueryLanguage.SPARQL, qStr);
+            TupleQueryResult r = q.evaluate();
+            while (r.hasNext()) {
+                return r.next().getBinding(varName).getValue();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            if (conn != null)
+                try { conn.close(); } catch (Exception e){ }
+        }
+        return null;
+    }
+}

--- a/geospatial/src/main/java/org/semagrow/geospatial/selector/BoundingBoxBase.java
+++ b/geospatial/src/main/java/org/semagrow/geospatial/selector/BoundingBoxBase.java
@@ -32,7 +32,7 @@ public class BoundingBoxBase {
 
         TriplePattern t1 = dataset.has(RDF.TYPE, VOID.DATASET);
         TriplePattern t2 = dataset.has(VOID.SPARQLENDPOINT, endpoint);
-        TriplePattern t3 = dataset.has(SEVOD_GEO.DATASET_BOUNDING_BOX, mbb);
+        TriplePattern t3 = dataset.has(SEVOD_GEO.DATASET_BOUNDING_POLYGON, mbb);
 
         GraphPattern body = GraphPatterns.and(t1,t2,t3);
         SelectQuery selectQuery = Queries.SELECT().select(mbb).where(body);

--- a/geospatial/src/main/java/org/semagrow/geospatial/selector/BoundingBoxPruner.java
+++ b/geospatial/src/main/java/org/semagrow/geospatial/selector/BoundingBoxPruner.java
@@ -1,0 +1,135 @@
+package org.semagrow.geospatial.selector;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.model.*;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.GEOF;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.*;
+import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
+import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy;
+import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
+import org.semagrow.geospatial.helpers.WktHelpers;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public final class BoundingBoxPruner {
+
+    private static final Set<String> nonDisjointStRelations;
+    private static final Set<Compare.CompareOp> leqOperators;
+
+    private static final Literal TRUE;
+    private static final Literal FALSE;
+
+    private static final EvaluationStrategy strategy;
+
+    static {
+        final ValueFactory vf = SimpleValueFactory.getInstance();
+
+        TRUE = vf.createLiteral(true);
+        FALSE = vf.createLiteral(false);
+
+        nonDisjointStRelations = new HashSet<>();
+
+        nonDisjointStRelations.add(GEOF.SF_EQUALS.stringValue());
+        nonDisjointStRelations.add(GEOF.SF_INTERSECTS.stringValue());
+        nonDisjointStRelations.add(GEOF.SF_TOUCHES.stringValue());
+        nonDisjointStRelations.add(GEOF.SF_WITHIN.stringValue());
+        nonDisjointStRelations.add(GEOF.SF_CONTAINS.stringValue());
+        nonDisjointStRelations.add(GEOF.SF_OVERLAPS.stringValue());
+        nonDisjointStRelations.add(GEOF.SF_CROSSES.stringValue());
+
+        nonDisjointStRelations.add(GEOF.EH_EQUALS.stringValue());
+        nonDisjointStRelations.add(GEOF.EH_MEET.stringValue());
+        nonDisjointStRelations.add(GEOF.EH_OVERLAP.stringValue());
+        nonDisjointStRelations.add(GEOF.EH_COVERS.stringValue());
+        nonDisjointStRelations.add(GEOF.EH_COVERED_BY.stringValue());
+        nonDisjointStRelations.add(GEOF.EH_INSIDE.stringValue());
+        nonDisjointStRelations.add(GEOF.EH_CONTAINS.stringValue());
+
+        nonDisjointStRelations.add(GEOF.RCC8_EQ.stringValue());
+        nonDisjointStRelations.add(GEOF.RCC8_EC.stringValue());
+        nonDisjointStRelations.add(GEOF.RCC8_PO.stringValue());
+        nonDisjointStRelations.add(GEOF.RCC8_TPP.stringValue());
+        nonDisjointStRelations.add(GEOF.RCC8_NTPPI.stringValue());
+        nonDisjointStRelations.add(GEOF.RCC8_NTPP.stringValue());
+        nonDisjointStRelations.add(GEOF.RCC8_TPPI.stringValue());
+
+        leqOperators = new HashSet<>();
+
+        leqOperators.add(Compare.CompareOp.LE);
+        leqOperators.add(Compare.CompareOp.LT);
+        leqOperators.add(Compare.CompareOp.EQ);
+
+        strategy = new StrictEvaluationStrategy(new TripleSource() {
+            @Override
+            public CloseableIteration<? extends Statement, QueryEvaluationException>
+                        getStatements( Resource resource,
+                                       IRI iri,
+                                       Value value,
+                                       Resource... resources) throws QueryEvaluationException {
+                return null;
+            }
+
+            @Override
+            public ValueFactory getValueFactory() {
+                return vf;
+            }
+        }, s -> null);
+    }
+
+    public static boolean prune(ValueExpr filter, String varName, Literal boundingBox) {
+        ValueExpr expr = rewriteFilter(filter, varName, boundingBox);
+        Value value = strategy.evaluate(expr, new EmptyBindingSet());
+        return value.equals(TRUE);
+    }
+
+    private static ValueExpr rewriteFilter(ValueExpr valueExpr, String varName, Value boundingBox) {
+
+        Value bboxWKT = WktHelpers.removeCRSfromWKT((Literal) boundingBox);
+
+        if (valueExpr instanceof FunctionCall) {
+            FunctionCall func = (FunctionCall) valueExpr;
+
+            if (checkArgs(func, varName)) {
+                if (nonDisjointStRelations.contains(func.getURI())) {
+
+                    FunctionCall new_func = new FunctionCall();
+                    new_func.setURI(GEOF.SF_DISJOINT.stringValue());
+                    new_func.addArgs(new ValueConstant(bboxWKT), func.getArgs().get(1));
+
+                    return new_func;
+                }
+            }
+        }
+        if (valueExpr instanceof Compare) {
+            Compare compare = (Compare) valueExpr;
+
+            if (leqOperators.contains(compare.getOperator())) {
+                FunctionCall func = (FunctionCall) compare.getLeftArg();
+
+                if (func.getURI().equals(GEOF.DISTANCE.stringValue()) && checkArgs(func, varName)) {
+
+                    FunctionCall buffer = new FunctionCall();
+                    buffer.setURI(GEOF.BUFFER.stringValue());
+                    buffer.addArgs(func.getArgs().get(1), compare.getRightArg(), func.getArgs().get(2));
+                    new ValueConstant(bboxWKT);
+
+                    FunctionCall new_func = new FunctionCall();
+                    new_func.setURI(GEOF.SF_DISJOINT.stringValue());
+                    new_func.addArgs(new ValueConstant(bboxWKT), buffer);
+
+                    return new_func;
+                }
+            }
+        }
+        return new ValueConstant(FALSE);
+    }
+
+    private static boolean checkArgs(FunctionCall functionCall, String varName) {
+        ValueExpr arg0 = functionCall.getArgs().get(0);
+        return (arg0 instanceof Var && ((Var) arg0).getName().equals(varName));
+    }
+}

--- a/geospatial/src/main/java/org/semagrow/geospatial/selector/GeospatialSourceSelector.java
+++ b/geospatial/src/main/java/org/semagrow/geospatial/selector/GeospatialSourceSelector.java
@@ -58,7 +58,7 @@ public class GeospatialSourceSelector extends SourceSelectorWrapper implements Q
 
         Collection<StatementPattern> patterns = StatementPatternCollector.process(expr);
         Collection<ValueExpr> filters = FilterCollector.process(expr);
-        Map<String,Set<Resource>> hasGeoMap = new HashMap<>();
+        //Map<String,Set<Resource>> hasGeoMap = new HashMap<>();
 
         for (StatementPattern pattern: patterns) {
             if (pattern.getPredicateVar().hasValue() && pattern.getPredicateVar().getValue().equals(GEO.AS_WKT)) {
@@ -90,14 +90,15 @@ public class GeospatialSourceSelector extends SourceSelectorWrapper implements Q
                 sources.removeAll(prunedSources);
 
                 selectorMap.put(pattern, sources);
-                hasGeoMap.put(pattern.getSubjectVar().getName(), endpoints);
+                //hasGeoMap.put(pattern.getSubjectVar().getName(), endpoints);
             }
         }
 
         /* search for corresponding hasGeometry patterns */
+        /*
         for (StatementPattern pattern: patterns) {
             if (pattern.getPredicateVar().hasValue() && pattern.getPredicateVar().getValue().equals(HAS_GEOMETRY)) {
-                /* we found a ?s geo:hasGeometry ?g */
+                // we found a ?s geo:hasGeometry ?g
 
                 Collection<SourceMetadata> candidateSources = getWrappedSelector().getSources(pattern, null, EmptyBindingSet.getInstance());
                 Set<SourceMetadata> prunedSources = new HashSet<>();
@@ -110,6 +111,7 @@ public class GeospatialSourceSelector extends SourceSelectorWrapper implements Q
                 selectorMap.put(pattern, prunedSources);
             }
         }
+        */
     }
 
     private Resource endpointOfSource(SourceMetadata source) {

--- a/geospatial/src/main/java/org/semagrow/geospatial/selector/GeospatialSourceSelector.java
+++ b/geospatial/src/main/java/org/semagrow/geospatial/selector/GeospatialSourceSelector.java
@@ -1,0 +1,128 @@
+package org.semagrow.geospatial.selector;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.GEO;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.algebra.StatementPattern;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.ValueExpr;
+import org.eclipse.rdf4j.query.algebra.helpers.StatementPatternCollector;
+import org.eclipse.rdf4j.query.algebra.helpers.VarNameCollector;
+import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
+import org.eclipse.rdf4j.repository.Repository;
+import org.semagrow.plan.util.BPGCollector;
+import org.semagrow.plan.util.FilterCollector;
+import org.semagrow.selector.QueryAwareSourceSelector;
+import org.semagrow.selector.SourceMetadata;
+import org.semagrow.selector.SourceSelector;
+import org.semagrow.selector.SourceSelectorWrapper;
+
+import java.util.*;
+
+public class GeospatialSourceSelector extends SourceSelectorWrapper implements QueryAwareSourceSelector  {
+
+    private ValueFactory vf = SimpleValueFactory.getInstance();
+    private IRI HAS_GEOMETRY = vf.createIRI(GEO.NAMESPACE, "hasGeometry");
+
+    private BoundingBoxBase boundingBoxBase = new BoundingBoxBase();
+    private Map<StatementPattern,Collection<SourceMetadata>> selectorMap = new HashMap<>();
+    private boolean processed = false;
+
+    public GeospatialSourceSelector(SourceSelector selector) {
+        super(selector);
+    }
+
+    public void setMetadataRepository(Repository metadata) {
+        boundingBoxBase.setMetadata(metadata);
+    }
+
+    @Override
+    public void processTupleExpr(TupleExpr expr) {
+        if (getWrappedSelector() instanceof QueryAwareSourceSelector) {
+            ((QueryAwareSourceSelector) getWrappedSelector()).processTupleExpr(expr);
+        }
+        Collection<TupleExpr> bpgs = BPGCollector.process(expr);
+        for (TupleExpr bpg: bpgs) {
+            processBPG(bpg);
+        }
+        processed = true;
+    }
+
+    private void processBPG(TupleExpr expr) {
+
+        Collection<StatementPattern> patterns = StatementPatternCollector.process(expr);
+        Collection<ValueExpr> filters = FilterCollector.process(expr);
+
+        for (StatementPattern patternAsWKT: patterns) {
+            if (patternAsWKT.getPredicateVar().hasValue() && patternAsWKT.getPredicateVar().getValue().equals(GEO.AS_WKT)) {
+                /* we found a ?s geo:asWKT ?o */
+
+                Set<SourceMetadata> sources = new HashSet<>();
+
+                /* search for corresponding filter */
+                for (ValueExpr filter: filters) {
+                    Set<String> filterVars = VarNameCollector.process(filter);
+                    if (filterVars.contains(patternAsWKT.getObjectVar().getName()) && filterVars.size() == 1) {
+
+                        Collection<SourceMetadata> candidateSources = getWrappedSelector().getSources(patternAsWKT, null, EmptyBindingSet.getInstance());
+                        for (SourceMetadata source: candidateSources) {
+                            Literal boundingBox = boundingBoxBase.getDatasetBoundingBox(endpointOfSource(source));
+                            if (boundingBox != null) {
+                                /* check if can prune source */
+                            }
+                            sources.add(source);
+                        }
+
+                        break; // use only first filter
+                    }
+                }
+                selectorMap.put(patternAsWKT, sources);
+
+                /* search for corresponding hasGeometry pattern */
+                for (StatementPattern patternHasGeometry: patterns) {
+                    if (patternHasGeometry.getPredicateVar().hasValue() &&
+                            patternHasGeometry.getPredicateVar().getValue().equals(HAS_GEOMETRY) &&
+                            patternHasGeometry.getObjectVar().getName().equals(patternAsWKT.getSubjectVar().getName())) {
+                        selectorMap.put(patternHasGeometry, sources);
+                    }
+                }
+            }
+        }
+    }
+
+    private Resource endpointOfSource(SourceMetadata source) {
+        return source.getSites().iterator().next().getID();
+    }
+
+    @Override
+    public Collection<SourceMetadata> getSources(StatementPattern pattern, Dataset dataset, BindingSet bindings)
+    {
+        if (processed && selectorMap.containsKey(pattern)) {
+            return selectorMap.get(pattern);
+        }
+        return super.getWrappedSelector().getSources(pattern, dataset, bindings);
+    }
+
+    private Collection<SourceMetadata> getSources(Iterable<StatementPattern> patterns, Dataset dataset, BindingSet bindings) {
+        Collection<SourceMetadata> list = new LinkedList<SourceMetadata>();
+        for(StatementPattern p : patterns) {
+            list.addAll(this.getSources(p, dataset, bindings));
+        }
+        return list;
+    }
+
+    @Override
+    public Collection<SourceMetadata> getSources(TupleExpr expr, Dataset dataset, BindingSet bindings)  {
+        if(expr instanceof StatementPattern) {
+            return getSources((StatementPattern)expr, dataset, bindings);
+        }
+
+        Collection<StatementPattern> patterns  = StatementPatternCollector.process(expr);
+        return getSources(patterns, dataset, bindings);
+    }
+}

--- a/geospatial/src/main/java/org/semagrow/geospatial/vocabulary/SEVOD_GEO.java
+++ b/geospatial/src/main/java/org/semagrow/geospatial/vocabulary/SEVOD_GEO.java
@@ -7,10 +7,10 @@ import org.semagrow.model.vocabulary.SEVOD;
 
 public final class SEVOD_GEO {
 
-    public static final IRI DATASET_BOUNDING_BOX;
+    public static final IRI DATASET_BOUNDING_POLYGON;
 
     static {
         ValueFactory vf = SimpleValueFactory.getInstance();
-        DATASET_BOUNDING_BOX = vf.createIRI(SEVOD.NAMESPACE + "datasetBoundingBox");
+        DATASET_BOUNDING_POLYGON = vf.createIRI(SEVOD.NAMESPACE + "datasetBoundingPolygon");
     }
 }

--- a/geospatial/src/main/java/org/semagrow/geospatial/vocabulary/SEVOD_GEO.java
+++ b/geospatial/src/main/java/org/semagrow/geospatial/vocabulary/SEVOD_GEO.java
@@ -1,0 +1,16 @@
+package org.semagrow.geospatial.vocabulary;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.semagrow.model.vocabulary.SEVOD;
+
+public final class SEVOD_GEO {
+
+    public static final IRI DATASET_BOUNDING_BOX;
+
+    static {
+        ValueFactory vf = SimpleValueFactory.getInstance();
+        DATASET_BOUNDING_BOX = vf.createIRI(SEVOD.NAMESPACE + "datasetBoundingBox");
+    }
+}

--- a/rdf4j/src/main/java/org/semagrow/sail/config/SemagrowSailFactory.java
+++ b/rdf4j/src/main/java/org/semagrow/sail/config/SemagrowSailFactory.java
@@ -5,6 +5,7 @@ import org.semagrow.config.*;
 import org.semagrow.connector.sparql.selector.AskSourceSelector;
 import org.semagrow.estimator.*;
 import org.semagrow.alignment.QueryTransformationImpl;
+import org.semagrow.geospatial.selector.GeospatialSourceSelector;
 import org.semagrow.sail.SemagrowSail;
 import org.semagrow.selector.*;
 import org.semagrow.alignment.SourceSelectorWithQueryTransform;
@@ -131,6 +132,8 @@ public class SemagrowSailFactory implements SailFactory, RepositoryResolverClien
             selector = new CachedSourceSelector(selector);
             selector = new PrefixQueryAwareSourceSelector(selector);
             ((PrefixQueryAwareSourceSelector) selector).setMetadataRepository(metadata);
+            selector = new GeospatialSourceSelector(selector);
+            ((GeospatialSourceSelector) selector).setMetadataRepository(metadata);
 
             return selector;
         }


### PR DESCRIPTION
Updates:
- Implementation of a Geospatial source selector for triple patterns of the form `?s geo:asWKT ?o`. The geospatial selector looks for filters of the `FILTER (r(?o,g))` or of the form `FILTER (geof:distance(?o,g,u) op d)`, where r is a non-disjoint geospatial function, g is a geometric literal, u is unit of measure, op is one of {<,<=,=}, and d is a numeric literal. Then, the selector prunes a given source if the pattern and its relevant filters won't produce any results in this source, based on the bounding polygon of all geometries in the source. The bounding polygon of the source is provided in the metadata.ttl file using the property svd:boundingPolygon for each dataset.
- The query optimizer return EmptySet if no plan was produced. This avoids causing query evaluation to throw an exception. Instead, query evaluation returns zero results.
- A Filter push-down Optimizer is called after the production of the final plan. This is done for pushing the filters inside the source query for the unions that were inserted by the optimizer in case of triple patterns that are evaluated in multiple sources.
- A small fix on the evaluation of the union operator; the unions are executed now in parallel (merge  instead of concat). This reverts https://github.com/semagrow/semagrow/commit/851168fedc5ae22707ed4ccd4087317750c87426 