### PR TITLE
Logs for kobe benchmarking engine 

### DIFF
--- a/core/src/main/java/org/semagrow/estimator/SimpleCardinalityEstimator.java
+++ b/core/src/main/java/org/semagrow/estimator/SimpleCardinalityEstimator.java
@@ -1,6 +1,5 @@
 package org.semagrow.estimator;
 
-import org.semagrow.art.Loggable;
 import org.semagrow.plan.Plan;
 import org.semagrow.statistics.Statistics;
 import org.semagrow.plan.operators.SourceQuery;
@@ -32,7 +31,6 @@ public class SimpleCardinalityEstimator implements CardinalityEstimator {
         this.statistics = statistics;
     }
 
-    @Loggable
     public BigInteger getCardinality(TupleExpr expr)  {
 
         if (expr instanceof StatementPattern)

--- a/core/src/main/java/org/semagrow/estimator/SimpleCostEstimator.java
+++ b/core/src/main/java/org/semagrow/estimator/SimpleCostEstimator.java
@@ -1,6 +1,5 @@
 package org.semagrow.estimator;
 
-import org.semagrow.art.Loggable;
 import org.semagrow.plan.operators.*;
 import org.semagrow.plan.Cost;
 import org.semagrow.plan.Plan;
@@ -31,7 +30,6 @@ public class SimpleCostEstimator implements CostEstimator {
         this.cardinalityEstimator = cardinalityEstimator;
     }
 
-    @Loggable
     public Cost getCost(TupleExpr expr) {
         // just favor remote queries.
         if (expr instanceof SourceQuery)

--- a/core/src/main/java/org/semagrow/evaluation/reactor/FederatedEvaluationStrategyImpl.java
+++ b/core/src/main/java/org/semagrow/evaluation/reactor/FederatedEvaluationStrategyImpl.java
@@ -161,7 +161,7 @@ public class FederatedEvaluationStrategyImpl extends EvaluationStrategyImpl {
     public Flux<BindingSet> evaluateReactorInternal(SourceQuery expr, BindingSet bindings)
             throws QueryEvaluationException
     {
-        logger.info("sq {} - Source query [{}] at source {}",
+        logger.debug("sq {} - Source query [{}] at source {}",
                 Math.abs(expr.hashCode()),
                 expr.getArg(),
                 expr.getSite());

--- a/core/src/main/java/org/semagrow/evaluation/util/LoggingUtil.java
+++ b/core/src/main/java/org/semagrow/evaluation/util/LoggingUtil.java
@@ -18,7 +18,7 @@ import java.net.URL;
 public class LoggingUtil {
 
     public static void logSourceQuery(Logger logger, SourceQuery expr) {
-        logger.info("sq {} - Source query [{}] at source {}",
+        logger.debug("sq {} - Source query [{}] at source {}",
                 Math.abs(expr.hashCode()),
                 expr,
                 //SPARQLQueryStringUtil.tupleExpr2Str(expr),
@@ -26,7 +26,7 @@ public class LoggingUtil {
     }
 
     public static void logFirstResult(Logger logger, String query, URL endpoint) {
-        logger.info("rq {} - Found first result.",
+        logger.debug("rq {} - Found first result.",
                 Math.abs((query + endpoint).hashCode()));
     }
 
@@ -37,13 +37,13 @@ public class LoggingUtil {
     }
 
     public static void logEnd(Logger logger, String query, URL endpoint, int results) {
-        logger.info("rq {} - Found {} results.",
+        logger.debug("rq {} - Found {} results.",
                 Math.abs((query + endpoint).hashCode()),
                 results);
     }
 
     public static void logRemote(Logger logger, RepositoryConnection conn, String sparqlQuery, java.net.URL endpoint, TupleExpr expr, Query query) {
-        logger.info("rc {} - rq {} - sq {} - Sending to [{}] query [{}] with {}",
+        logger.debug("rc {} - rq {} - sq {} - Sending to [{}] query [{}] with {}",
                 conn.hashCode(),
                 Math.abs((sparqlQuery+endpoint).hashCode()),
                 Math.abs(expr.getParentNode().getParentNode().hashCode()),

--- a/core/src/main/java/org/semagrow/plan/DPPlanOptimizer.java
+++ b/core/src/main/java/org/semagrow/plan/DPPlanOptimizer.java
@@ -122,7 +122,7 @@ public class DPPlanOptimizer
         prunePlans(fullPlans);
 
         if (!fullPlans.isEmpty()) {
-            logger.info("Found {} complete optimal plans", fullPlans.size());
+            logger.debug("Found {} complete optimal plans", fullPlans.size());
         } else {
             logger.warn("Found no complete plans");
         }

--- a/core/src/main/java/org/semagrow/plan/DPPlanOptimizer.java
+++ b/core/src/main/java/org/semagrow/plan/DPPlanOptimizer.java
@@ -1,6 +1,5 @@
 package org.semagrow.plan;
 
-import org.semagrow.art.Loggable;
 import org.semagrow.plan.util.CombinationIterator;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.Dataset;
@@ -86,7 +85,6 @@ public class DPPlanOptimizer
         return  plan1.getProperties().isComparable(plan2.getProperties());
     }
 
-    @Loggable
     public Optional<Plan> getBestPlan(Collection<TupleExpr> exprs, BindingSet bindings, Dataset dataset) {
 
         Map<Set<Integer>,PlanCollection> optPlans = new HashMap<>();

--- a/core/src/main/java/org/semagrow/plan/SimpleQueryCompiler.java
+++ b/core/src/main/java/org/semagrow/plan/SimpleQueryCompiler.java
@@ -7,6 +7,7 @@ import org.eclipse.rdf4j.query.algebra.QueryRoot;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.*;
 import org.eclipse.rdf4j.query.algebra.evaluation.util.QueryOptimizerList;
+import org.semagrow.art.Loggable;
 import org.semagrow.estimator.CardinalityEstimatorResolver;
 import org.semagrow.estimator.CostEstimatorResolver;
 import org.semagrow.local.LocalSite;
@@ -38,6 +39,7 @@ public class SimpleQueryCompiler implements QueryCompiler {
     }
 
     @Override
+    @Loggable
     public Plan compile(QueryRoot query, Dataset dataset, BindingSet bindings) {
 
         // transformations on logical query.
@@ -46,9 +48,7 @@ public class SimpleQueryCompiler implements QueryCompiler {
         // split query to queryblocks.
         QueryBlock blockRoot = blockify(query, dataset, bindings);
 
-        if (sourceSelector instanceof QueryAwareSourceSelector) {
-            ((QueryAwareSourceSelector) sourceSelector).processTupleExpr(query);
-        }
+        performSourceSelection(query);
 
         // infer interesting properties for each query block.
         blockRoot.visit(new InterestingPropertiesVisitor());     // infer interesting properties for each block
@@ -68,6 +68,13 @@ public class SimpleQueryCompiler implements QueryCompiler {
         optimize(plan, dataset, bindings);
 
         return plan;
+    }
+
+    @Loggable
+    private void performSourceSelection(QueryRoot query) {
+        if (sourceSelector instanceof QueryAwareSourceSelector) {
+            ((QueryAwareSourceSelector) sourceSelector).processTupleExpr(query);
+        }
     }
 
     private QueryBlock blockify(QueryRoot query, Dataset dataset, BindingSet bindings) {

--- a/core/src/main/java/org/semagrow/plan/SimpleQueryCompiler.java
+++ b/core/src/main/java/org/semagrow/plan/SimpleQueryCompiler.java
@@ -15,6 +15,8 @@ import org.semagrow.plan.optimizer.FilterPlanOptimizer;
 import org.semagrow.plan.queryblock.*;
 import org.semagrow.selector.QueryAwareSourceSelector;
 import org.semagrow.selector.SourceSelector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 
@@ -24,6 +26,8 @@ import java.util.Collection;
  * @since 2.0
  */
 public class SimpleQueryCompiler implements QueryCompiler {
+
+    protected final Logger logger = LoggerFactory.getLogger(SimpleQueryCompiler.class);
 
     private CostEstimatorResolver costEstimatorResolver;
     private CardinalityEstimatorResolver cardinalityEstimatorResolver;
@@ -66,6 +70,8 @@ public class SimpleQueryCompiler implements QueryCompiler {
         Plan plan = (plans.isEmpty()) ? new Plan(new EmptySet()) : plans.iterator().next();
 
         optimize(plan, dataset, bindings);
+
+        logger.info("Query execution plan: {}", plan);
 
         return plan;
     }

--- a/core/src/main/java/org/semagrow/plan/SimpleQueryCompiler.java
+++ b/core/src/main/java/org/semagrow/plan/SimpleQueryCompiler.java
@@ -53,7 +53,7 @@ public class SimpleQueryCompiler implements QueryCompiler {
         // split query to queryblocks.
         QueryBlock blockRoot = blockify(query, dataset, bindings);
 
-        performSourceSelection(query);
+        sourceSelection(query);
 
         // infer interesting properties for each query block.
         blockRoot.visit(new InterestingPropertiesVisitor());     // infer interesting properties for each block
@@ -72,14 +72,14 @@ public class SimpleQueryCompiler implements QueryCompiler {
 
         optimize(plan, dataset, bindings);
 
-        logger.info("Query execution plan: {}", plan);
-        logger.info("Sources: {}", EndpointCollector.process(plan).size());
+        logger.info("execution plan: {}", plan);
+        logger.info("sources: {}", EndpointCollector.process(plan).size());
 
         return plan;
     }
 
     @Loggable
-    private void performSourceSelection(QueryRoot query) {
+    private void sourceSelection(QueryRoot query) {
         if (sourceSelector instanceof QueryAwareSourceSelector) {
             ((QueryAwareSourceSelector) sourceSelector).processTupleExpr(query);
         }

--- a/core/src/main/java/org/semagrow/plan/SimpleQueryCompiler.java
+++ b/core/src/main/java/org/semagrow/plan/SimpleQueryCompiler.java
@@ -13,6 +13,7 @@ import org.semagrow.estimator.CostEstimatorResolver;
 import org.semagrow.local.LocalSite;
 import org.semagrow.plan.optimizer.FilterPlanOptimizer;
 import org.semagrow.plan.queryblock.*;
+import org.semagrow.plan.util.EndpointCollector;
 import org.semagrow.selector.QueryAwareSourceSelector;
 import org.semagrow.selector.SourceSelector;
 import org.slf4j.Logger;
@@ -72,6 +73,7 @@ public class SimpleQueryCompiler implements QueryCompiler {
         optimize(plan, dataset, bindings);
 
         logger.info("Query execution plan: {}", plan);
+        logger.info("Sources: {}", EndpointCollector.process(plan));
 
         return plan;
     }

--- a/core/src/main/java/org/semagrow/plan/SimpleQueryCompiler.java
+++ b/core/src/main/java/org/semagrow/plan/SimpleQueryCompiler.java
@@ -73,7 +73,7 @@ public class SimpleQueryCompiler implements QueryCompiler {
         optimize(plan, dataset, bindings);
 
         logger.info("Query execution plan: {}", plan);
-        logger.info("Sources: {}", EndpointCollector.process(plan));
+        logger.info("Sources: {}", EndpointCollector.process(plan).size());
 
         return plan;
     }

--- a/core/src/main/java/org/semagrow/plan/SimpleQueryCompiler.java
+++ b/core/src/main/java/org/semagrow/plan/SimpleQueryCompiler.java
@@ -7,6 +7,7 @@ import org.eclipse.rdf4j.query.algebra.QueryRoot;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.*;
 import org.eclipse.rdf4j.query.algebra.evaluation.util.QueryOptimizerList;
+import org.semagrow.art.LogUtils;
 import org.semagrow.art.Loggable;
 import org.semagrow.estimator.CardinalityEstimatorResolver;
 import org.semagrow.estimator.CostEstimatorResolver;
@@ -53,7 +54,11 @@ public class SimpleQueryCompiler implements QueryCompiler {
         // split query to queryblocks.
         QueryBlock blockRoot = blockify(query, dataset, bindings);
 
+        long t1 = System.currentTimeMillis();
+
         sourceSelection(query);
+
+        long t2 = System.currentTimeMillis();
 
         // infer interesting properties for each query block.
         blockRoot.visit(new InterestingPropertiesVisitor());     // infer interesting properties for each block
@@ -72,8 +77,15 @@ public class SimpleQueryCompiler implements QueryCompiler {
 
         optimize(plan, dataset, bindings);
 
+        long t3 = System.currentTimeMillis();
+
+        String compilationReport = "" +
+                "Source Selection Time: " + (t2-t1) + ", " +
+                "Compile Time: " + (t3-t2) + ", " +
+                "Sources: " + EndpointCollector.process(plan).size();
+        LogUtils.appendKobeReport(compilationReport);
+
         logger.info("execution plan: {}", plan);
-        logger.info("sources: {}", EndpointCollector.process(plan).size());
 
         return plan;
     }

--- a/core/src/main/java/org/semagrow/plan/SimpleQueryCompiler.java
+++ b/core/src/main/java/org/semagrow/plan/SimpleQueryCompiler.java
@@ -80,8 +80,8 @@ public class SimpleQueryCompiler implements QueryCompiler {
         long t3 = System.currentTimeMillis();
 
         String compilationReport = "" +
-                "Source Selection Time: " + (t2-t1) + ", " +
-                "Compile Time: " + (t3-t2) + ", " +
+                "Source Selection Time: " + (t2-t1) + " - " +
+                "Compile Time: " + (t3-t2) + " - " +
                 "Sources: " + EndpointCollector.process(plan).size();
         LogUtils.appendKobeReport(compilationReport);
 

--- a/core/src/main/java/org/semagrow/plan/SimpleQueryDecomposer.java
+++ b/core/src/main/java/org/semagrow/plan/SimpleQueryDecomposer.java
@@ -1,7 +1,6 @@
 package org.semagrow.plan;
 
 import org.eclipse.rdf4j.query.algebra.helpers.StatementPatternCollector;
-import org.semagrow.art.Loggable;
 import org.semagrow.plan.optimizer.ExtensionOptimizer;
 import org.semagrow.plan.optimizer.LimitPushDownOptimizer;
 import org.semagrow.plan.util.BPGCollector;
@@ -66,7 +65,6 @@ public class SimpleQueryDecomposer implements QueryDecomposer
      */
 
     @Override
-    @Loggable
     public void decompose(TupleExpr expr, Dataset dataset, BindingSet bindings)
     {
         /*

--- a/core/src/main/java/org/semagrow/plan/util/EndpointCollector.java
+++ b/core/src/main/java/org/semagrow/plan/util/EndpointCollector.java
@@ -1,0 +1,27 @@
+package org.semagrow.plan.util;
+
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.semagrow.plan.AbstractPlanVisitor;
+import org.semagrow.plan.operators.SourceQuery;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+public class EndpointCollector extends AbstractPlanVisitor<RuntimeException> {
+
+    private Collection<String> endpoints;
+
+    private EndpointCollector() {
+        endpoints = new HashSet<>();
+    }
+
+    public static Collection<String> process(TupleExpr expr){
+        EndpointCollector endpointCollector = new EndpointCollector();
+        expr.visit(endpointCollector);
+        return endpointCollector.endpoints;
+    }
+
+    public void meet(SourceQuery sourceQuery) {
+        endpoints.add(sourceQuery.getSite().toString());
+    }
+}

--- a/core/src/main/java/org/semagrow/selector/CachedSourceSelector.java
+++ b/core/src/main/java/org/semagrow/selector/CachedSourceSelector.java
@@ -1,6 +1,5 @@
 package org.semagrow.selector;
 
-import org.semagrow.art.Loggable;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
@@ -26,7 +25,6 @@ public class CachedSourceSelector extends SourceSelectorWrapper
     }
 
     @Override
-    @Loggable
     public Collection<SourceMetadata> getSources(StatementPattern pattern, Dataset dataset, BindingSet bindings)
     {
         Collection<SourceMetadata> retv;

--- a/core/src/main/java/org/semagrow/selector/VOIDSourceSelector.java
+++ b/core/src/main/java/org/semagrow/selector/VOIDSourceSelector.java
@@ -1,6 +1,5 @@
 package org.semagrow.selector;
 
-import org.semagrow.art.Loggable;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Value;
@@ -35,7 +34,6 @@ public class VOIDSourceSelector extends VOIDBase
 
     protected SiteResolver getSiteResolver() { return this.siteResolver; }
 
-    @Loggable
     public Collection<SourceMetadata> getSources(StatementPattern pattern, Dataset dataset, BindingSet bindings) {
 
         if (!pattern.getSubjectVar().hasValue() &&
@@ -46,7 +44,6 @@ public class VOIDSourceSelector extends VOIDBase
             return new LinkedList<SourceMetadata>(datasetsToSourceMetadata(pattern, getDatasets(pattern)));
     }
 
-    @Loggable
     public Collection<SourceMetadata> getSources(TupleExpr expr, Dataset dataset, BindingSet bindings) {
 
         if (expr instanceof StatementPattern)

--- a/http-endpoint/pom.xml
+++ b/http-endpoint/pom.xml
@@ -75,11 +75,6 @@
             <artifactId>jsp-api</artifactId>
             <version>2.1</version>
         </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>1.14</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/http-endpoint/pom.xml
+++ b/http-endpoint/pom.xml
@@ -75,7 +75,11 @@
             <artifactId>jsp-api</artifactId>
             <version>2.1</version>
         </dependency>
-
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.14</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/http-endpoint/src/main/java/org/semagrow/http/controllers/AbstractQueryController.java
+++ b/http-endpoint/src/main/java/org/semagrow/http/controllers/AbstractQueryController.java
@@ -1,5 +1,6 @@
 package org.semagrow.http.controllers;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
 import org.eclipse.rdf4j.common.webapp.util.HttpServerUtil;
@@ -16,6 +17,7 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.sail.config.RepositoryResolver;
+import org.semagrow.art.LogUtils;
 import org.semagrow.repository.SemagrowRepositoryResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,24 +79,18 @@ public abstract class AbstractQueryController extends WebContentGenerator implem
             }
         }
 
-        int qryCode = 0;
-        if (logger.isInfoEnabled() || logger.isDebugEnabled()) {
-            qryCode = String.valueOf(queryStr).hashCode();
-        }
-
         boolean headersOnly = false;
         if (METHOD_GET.equals(reqMethod)) {
-            logger.info("GET query {}", qryCode);
+            logger.info("GET query {}", queryStr);
         }
         else if (METHOD_HEAD.equals(reqMethod)) {
-            logger.info("HEAD query {}", qryCode);
+            logger.info("HEAD query {}", queryStr);
             headersOnly = true;
         }
         else if (METHOD_POST.equals(reqMethod)) {
-            logger.info("POST query {}", qryCode);
+            logger.info("POST query {}", queryStr);
         }
-
-        logger.debug("query {} = {}", qryCode, queryStr);
+        logger.info("[{}] New query with MD5: {}", LogUtils.getNewQueryID(), DigestUtils.md5Hex(queryStr));
 
         if (queryStr != null) {
 

--- a/http-endpoint/src/main/java/org/semagrow/http/controllers/AbstractQueryController.java
+++ b/http-endpoint/src/main/java/org/semagrow/http/controllers/AbstractQueryController.java
@@ -90,7 +90,7 @@ public abstract class AbstractQueryController extends WebContentGenerator implem
         else if (METHOD_POST.equals(reqMethod)) {
             logger.info("POST query {}", queryStr);
         }
-        logger.info("[{}] New query with MD5: {}", LogUtils.getNewQueryID(), DigestUtils.md5Hex(queryStr));
+        logger.info("Query MD5: {}", DigestUtils.md5Hex(queryStr));
 
         if (queryStr != null) {
 

--- a/http-endpoint/src/main/java/org/semagrow/http/controllers/AbstractQueryController.java
+++ b/http-endpoint/src/main/java/org/semagrow/http/controllers/AbstractQueryController.java
@@ -79,6 +79,7 @@ public abstract class AbstractQueryController extends WebContentGenerator implem
             }
         }
 
+        LogUtils.setMDC();
         boolean headersOnly = false;
         if (METHOD_GET.equals(reqMethod)) {
             logger.info("GET query {}", queryStr);

--- a/http-endpoint/src/main/java/org/semagrow/http/controllers/AbstractQueryController.java
+++ b/http-endpoint/src/main/java/org/semagrow/http/controllers/AbstractQueryController.java
@@ -93,7 +93,10 @@ public abstract class AbstractQueryController extends WebContentGenerator implem
 
         if (queryStr != null) {
             if (LogUtils.hasKobeQueryDesc(queryStr)) {
-                logger.info(LogUtils.getKobeQueryDesc(queryStr));
+                String kobeQueryDesc = LogUtils.getKobeQueryDesc(queryStr);
+                logger.debug(kobeQueryDesc);
+                LogUtils.initKobeReport();
+                LogUtils.appendKobeReport(kobeQueryDesc);
             }
 
             Repository repository = getRepository(request);

--- a/http-endpoint/src/main/java/org/semagrow/http/controllers/AbstractQueryController.java
+++ b/http-endpoint/src/main/java/org/semagrow/http/controllers/AbstractQueryController.java
@@ -1,6 +1,5 @@
 package org.semagrow.http.controllers;
 
-import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
 import org.eclipse.rdf4j.common.webapp.util.HttpServerUtil;
@@ -91,9 +90,11 @@ public abstract class AbstractQueryController extends WebContentGenerator implem
         else if (METHOD_POST.equals(reqMethod)) {
             logger.info("POST query {}", queryStr);
         }
-        logger.info("Query MD5: {}", DigestUtils.md5Hex(queryStr));
 
         if (queryStr != null) {
+            if (LogUtils.hasKobeQueryDesc(queryStr)) {
+                logger.info(LogUtils.getKobeQueryDesc(queryStr));
+            }
 
             Repository repository = getRepository(request);
             RepositoryConnection repositoryCon = getRepositoryConnection(request);

--- a/http-endpoint/src/main/webapp/WEB-INF/classes/logback.groovy
+++ b/http-endpoint/src/main/webapp/WEB-INF/classes/logback.groovy
@@ -1,0 +1,27 @@
+
+appender( "PROCFLOW", ConsoleAppender ) {
+  encoder( PatternLayoutEncoder) {
+    pattern = "%.-1level - %date{ISO8601} - [%10.10thread] - %20.-20logger{0} - %.12X{uuid} - %X{nestingLevel} - %msg%n"
+  }
+}
+
+appender( "CONSOLE", ConsoleAppender ) {
+  encoder( PatternLayoutEncoder) {
+    pattern = "%.-1level - %date{ISO8601} - [%10.10thread] - %20.-20logger{0} - %msg%n"
+  }
+}
+
+
+logger( "org.semagrow", WARN , ["PROCFLOW"], false )
+logger( "org.semagrow.plan", INFO, ["PROCFLOW"], false)
+logger( "org.semagrow.estimator", WARN, ["PROCFLOW"], false)
+logger( "org.semagrow.evaluation", INFO, ["PROCFLOW"], false)
+logger( "org.semagrow.connector.sparql", INFO, ["PROCFLOW"], false)
+logger( "org.semagrow.connector.sparql.execution.TupleQueryResultPublisher", WARN, ["PROCFLOW"], false)
+logger( "org.semagrow.http", INFO, ["PROCFLOW"], false )
+logger( "org.semagrow.query", INFO, ["PROCFLOW"], false )
+logger( "org.semagrow.sail", INFO, ["PROCFLOW"], false )
+
+logger( "reactor", WARN, ["PROCFLOW"], false )
+
+root( INFO, ["CONSOLE"] )

--- a/http-endpoint/src/main/webapp/WEB-INF/classes/logback.groovy
+++ b/http-endpoint/src/main/webapp/WEB-INF/classes/logback.groovy
@@ -1,7 +1,7 @@
 
 appender( "PROCFLOW", ConsoleAppender ) {
   encoder( PatternLayoutEncoder) {
-    pattern = "%.-1level - %date{ISO8601} - [%10.10thread] - %20.-20logger{0} - %.12X{uuid} - %X{nestingLevel} - %msg%n"
+    pattern = "%.-1level - %date{ISO8601} - [%10.10thread] - %20.-20logger{0} - %.12X{uuid} - %msg%n"
   }
 }
 

--- a/http-endpoint/src/main/webapp/WEB-INF/classes/logback.groovy
+++ b/http-endpoint/src/main/webapp/WEB-INF/classes/logback.groovy
@@ -21,6 +21,7 @@ logger( "org.semagrow.connector.sparql.execution.TupleQueryResultPublisher", WAR
 logger( "org.semagrow.http", INFO, ["PROCFLOW"], false )
 logger( "org.semagrow.query", INFO, ["PROCFLOW"], false )
 logger( "org.semagrow.sail", INFO, ["PROCFLOW"], false )
+logger( "org.semagrow.http.views.TupleQueryResultView", OFF, ["PROCFLOW"], false )
 
 logger( "reactor", WARN, ["PROCFLOW"], false )
 

--- a/monitor/src/main/java/org/semagrow/art/LogUtils.java
+++ b/monitor/src/main/java/org/semagrow/art/LogUtils.java
@@ -6,12 +6,13 @@ import java.util.UUID;
 
 public final class LogUtils {
 
-    public static String getNewQueryID() {
-        MDC.put("qid", UUID.randomUUID().toString().substring(0,8));
-        return MDC.get("qid");
+    public static void setMDCifNull() {
+        if (MDC.get("uuid") == null) {
+            setMDC();
+        }
     }
 
-    public static String getQueryID() {
-        return MDC.get("qid");
+    public static void setMDC() {
+        MDC.put("uuid", UUID.randomUUID().toString());
     }
 }

--- a/monitor/src/main/java/org/semagrow/art/LogUtils.java
+++ b/monitor/src/main/java/org/semagrow/art/LogUtils.java
@@ -16,4 +16,17 @@ public final class LogUtils {
         MDC.put("nestingLevel", "1");
         MDC.put("uuid", UUID.randomUUID().toString());
     }
+
+    public static boolean hasKobeQueryDesc(String query) {
+        String keyword = "#kobeQueryDesc ";
+        return query.startsWith(keyword);
+    }
+
+    public static String getKobeQueryDesc(String query) {
+        String keyword = "#kobeQueryDesc ";
+        assert hasKobeQueryDesc(query);
+        int i = keyword.length() - 1;
+        int j = query.indexOf('\n') - 1;
+        return query.substring(i,j);
+    }
 }

--- a/monitor/src/main/java/org/semagrow/art/LogUtils.java
+++ b/monitor/src/main/java/org/semagrow/art/LogUtils.java
@@ -39,6 +39,6 @@ public final class LogUtils {
     }
 
     public static void appendKobeReport(String s) {
-        MDC.put("kobeReport", getKobeReport() + ", " + s);
+        MDC.put("kobeReport", getKobeReport() + " - " + s);
     }
 }

--- a/monitor/src/main/java/org/semagrow/art/LogUtils.java
+++ b/monitor/src/main/java/org/semagrow/art/LogUtils.java
@@ -29,4 +29,16 @@ public final class LogUtils {
         int j = query.indexOf('\n');
         return query.substring(i,j);
     }
+
+    public static void initKobeReport() {
+        MDC.put("kobeReport", "");
+    }
+
+    public static String getKobeReport() {
+        return MDC.get("kobeReport");
+    }
+
+    public static void appendKobeReport(String s) {
+        MDC.put("kobeReport", getKobeReport() + ", " + s);
+    }
 }

--- a/monitor/src/main/java/org/semagrow/art/LogUtils.java
+++ b/monitor/src/main/java/org/semagrow/art/LogUtils.java
@@ -1,0 +1,17 @@
+package org.semagrow.art;
+
+import org.slf4j.MDC;
+
+import java.util.UUID;
+
+public final class LogUtils {
+
+    public static String getNewQueryID() {
+        MDC.put("qid", UUID.randomUUID().toString().substring(0,8));
+        return MDC.get("qid");
+    }
+
+    public static String getQueryID() {
+        return MDC.get("qid");
+    }
+}

--- a/monitor/src/main/java/org/semagrow/art/LogUtils.java
+++ b/monitor/src/main/java/org/semagrow/art/LogUtils.java
@@ -13,6 +13,7 @@ public final class LogUtils {
     }
 
     public static void setMDC() {
+        MDC.put("nestingLevel", "1");
         MDC.put("uuid", UUID.randomUUID().toString());
     }
 }

--- a/monitor/src/main/java/org/semagrow/art/MethodLogger.java
+++ b/monitor/src/main/java/org/semagrow/art/MethodLogger.java
@@ -31,7 +31,7 @@ public class MethodLogger {
             result = point.proceed();
             long duration = System.currentTimeMillis() - start;
             logger.debug( "Exit  {}", method.getName());
-            logger.info("{} time: " + duration);
+            logger.info("{} time: {}", method.getName(), duration);
             event.finalize();
         } catch (Throwable throwable) {
             throwable.printStackTrace();

--- a/monitor/src/main/java/org/semagrow/art/MethodLogger.java
+++ b/monitor/src/main/java/org/semagrow/art/MethodLogger.java
@@ -26,9 +26,9 @@ public class MethodLogger {
             Method method = MethodSignature.class.cast(point.getSignature()).getMethod();
             Logger logger = LoggerFactory.getLogger(method.getDeclaringClass());
             LogExprProcessing event = new LogExprProcessing();
-            logger.info( "[{}] Enter {}", LogUtils.getQueryID(), method.getName());
+            logger.info( "Enter {}", method.getName());
             result = point.proceed();
-            logger.info( "[{}] Exit  {}", LogUtils.getQueryID(), method.getName());
+            logger.info( "Exit  {}", method.getName());
             event.finalize();
         } catch (Throwable throwable) {
             throwable.printStackTrace();

--- a/monitor/src/main/java/org/semagrow/art/MethodLogger.java
+++ b/monitor/src/main/java/org/semagrow/art/MethodLogger.java
@@ -31,7 +31,7 @@ public class MethodLogger {
             result = point.proceed();
             long duration = System.currentTimeMillis() - start;
             logger.debug( "Exit  {}", method.getName());
-            logger.info("{} time: {}", method.getName(), duration);
+            logger.debug("{} time: {}", method.getName(), duration);
             event.finalize();
         } catch (Throwable throwable) {
             throwable.printStackTrace();

--- a/monitor/src/main/java/org/semagrow/art/MethodLogger.java
+++ b/monitor/src/main/java/org/semagrow/art/MethodLogger.java
@@ -26,9 +26,12 @@ public class MethodLogger {
             Method method = MethodSignature.class.cast(point.getSignature()).getMethod();
             Logger logger = LoggerFactory.getLogger(method.getDeclaringClass());
             LogExprProcessing event = new LogExprProcessing();
-            logger.info( "Enter {}", method.getName());
+            logger.debug( "Enter {}", method.getName());
+            long start = System.currentTimeMillis();
             result = point.proceed();
-            logger.info( "Exit  {}", method.getName());
+            long duration = System.currentTimeMillis() - start;
+            logger.debug( "Exit  {}", method.getName());
+            logger.info("{} time: " + duration);
             event.finalize();
         } catch (Throwable throwable) {
             throwable.printStackTrace();

--- a/monitor/src/main/java/org/semagrow/art/MethodLogger.java
+++ b/monitor/src/main/java/org/semagrow/art/MethodLogger.java
@@ -26,9 +26,9 @@ public class MethodLogger {
             Method method = MethodSignature.class.cast(point.getSignature()).getMethod();
             Logger logger = LoggerFactory.getLogger(method.getDeclaringClass());
             LogExprProcessing event = new LogExprProcessing();
-            logger.info( "Enter {}", method.getName());
+            logger.info( "[{}] Enter {}", LogUtils.getQueryID(), method.getName());
             result = point.proceed();
-            logger.info( "Exit  {}", method.getName());
+            logger.info( "[{}] Exit  {}", LogUtils.getQueryID(), method.getName());
             event.finalize();
         } catch (Throwable throwable) {
             throwable.printStackTrace();

--- a/rdf4j/pom.xml
+++ b/rdf4j/pom.xml
@@ -23,6 +23,11 @@
           <version>${project.version}</version>
       </dependency>
       <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>semagrow-monitor</artifactId>
+          <version>${project.version}</version>
+      </dependency>
+      <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>semagrow-core</artifactId>
       <version>${project.version}</version>

--- a/rdf4j/src/main/java/org/semagrow/query/impl/SemagrowSailQuery.java
+++ b/rdf4j/src/main/java/org/semagrow/query/impl/SemagrowSailQuery.java
@@ -1,5 +1,6 @@
 package org.semagrow.query.impl;
 
+import org.semagrow.art.LogUtils;
 import org.semagrow.query.SemagrowQuery;
 import org.semagrow.sail.SemagrowSailConnection;
 
@@ -60,7 +61,7 @@ public class SemagrowSailQuery extends SailQuery implements SemagrowQuery
          * SemagrowSailTupleQuery sets a new context for this thread; this instance
          * maintains a copy, which is passed to worker threads.
          */
-        org.slf4j.MDC.put( "uuid", UUID.randomUUID().toString() );
+        LogUtils.setMDCifNull();
 
         this.contextMap = org.slf4j.MDC.getCopyOfContextMap();
     }

--- a/rdf4j/src/main/java/org/semagrow/query/impl/SemagrowSailTupleQuery.java
+++ b/rdf4j/src/main/java/org/semagrow/query/impl/SemagrowSailTupleQuery.java
@@ -67,7 +67,7 @@ public class SemagrowSailTupleQuery extends SemagrowSailQuery implements Semagro
         QueryResults.report(queryResult, handler);
         */
 
-        logger.info("Evaluate query with handler");
+        logger.debug("Evaluate query with handler");
         TupleExpr tupleExpr = getParsedQuery().getTupleExpr();
 
         try {

--- a/rdf4j/src/main/java/org/semagrow/query/impl/SemagrowSailTupleQuery.java
+++ b/rdf4j/src/main/java/org/semagrow/query/impl/SemagrowSailTupleQuery.java
@@ -81,7 +81,7 @@ public class SemagrowSailTupleQuery extends SemagrowSailQuery implements Semagro
 
             //result = enforceMaxQueryTime(bindingsIter);
 
-            logger.info( "Enter execute");
+            long start = System.currentTimeMillis();
 
             CountDownLatch latch = new CountDownLatch(1);
 
@@ -102,7 +102,8 @@ public class SemagrowSailTupleQuery extends SemagrowSailQuery implements Semagro
                     throw new QueryEvaluationException(subscriberAdapter.errorThrown);
             }
 
-            logger.info( "Exit  execute");
+            long duration = System.currentTimeMillis() - start;
+            logger.info( "execution time: {}", duration);
         }
         catch (SailException e) {
             throw new QueryEvaluationException(e.getMessage(), e);

--- a/rdf4j/src/main/java/org/semagrow/query/impl/SemagrowSailTupleQuery.java
+++ b/rdf4j/src/main/java/org/semagrow/query/impl/SemagrowSailTupleQuery.java
@@ -1,5 +1,6 @@
 package org.semagrow.query.impl;
 
+import org.semagrow.art.LogUtils;
 import org.semagrow.query.SemagrowTupleQuery;
 import org.semagrow.sail.SemagrowSailConnection;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
@@ -67,7 +68,7 @@ public class SemagrowSailTupleQuery extends SemagrowSailQuery implements Semagro
         QueryResults.report(queryResult, handler);
         */
 
-        logger.info("SemaGrow query evaluate with handler {}", this.queryString);
+        logger.info("SemaGrow query evaluate with handler {}", this.queryString.replace('\n',' '));
         TupleExpr tupleExpr = getParsedQuery().getTupleExpr();
 
         try {
@@ -81,7 +82,7 @@ public class SemagrowSailTupleQuery extends SemagrowSailQuery implements Semagro
 
             //result = enforceMaxQueryTime(bindingsIter);
 
-            logger.info("Query evaluation Start.");
+            logger.info("[{}] Query evaluation Start.", LogUtils.getQueryID());
 
             CountDownLatch latch = new CountDownLatch(1);
 
@@ -102,7 +103,7 @@ public class SemagrowSailTupleQuery extends SemagrowSailQuery implements Semagro
                     throw new QueryEvaluationException(subscriberAdapter.errorThrown);
             }
 
-            logger.info("Query evaluation End.");
+            logger.info("[{}] Query evaluation End.", LogUtils.getQueryID());
         }
         catch (SailException e) {
             throw new QueryEvaluationException(e.getMessage(), e);

--- a/rdf4j/src/main/java/org/semagrow/query/impl/SemagrowSailTupleQuery.java
+++ b/rdf4j/src/main/java/org/semagrow/query/impl/SemagrowSailTupleQuery.java
@@ -154,12 +154,12 @@ public class SemagrowSailTupleQuery extends SemagrowSailQuery implements Semagro
                         handler.startQueryResult(new ArrayList<>(bindings.getBindingNames()));
                     }
                     isStarted = true;
-                    logger.info("Found first result");
+                    logger.debug("Found first result");
                 }
                 synchronized (handler) {
                     handler.handleSolution(bindings);
                 }
-                logger.info("Found {}", bindings);
+                logger.debug("Found {}", bindings);
                 resultsCount++;
             } catch (TupleQueryResultHandlerException e) {
                 subscription.cancel();
@@ -198,7 +198,7 @@ public class SemagrowSailTupleQuery extends SemagrowSailQuery implements Semagro
 
 
         public void onComplete() {
-            logger.info("Found {} results", resultsCount);
+            logger.debug("Found {} results", resultsCount);
             if (isStarted) {
                 try {
                     synchronized (handler) {

--- a/rdf4j/src/main/java/org/semagrow/query/impl/SemagrowSailTupleQuery.java
+++ b/rdf4j/src/main/java/org/semagrow/query/impl/SemagrowSailTupleQuery.java
@@ -15,7 +15,6 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.rmi.runtime.Log;
 
 import java.util.*;
 import java.util.concurrent.CountDownLatch;

--- a/rdf4j/src/main/java/org/semagrow/query/impl/SemagrowSailTupleQuery.java
+++ b/rdf4j/src/main/java/org/semagrow/query/impl/SemagrowSailTupleQuery.java
@@ -1,6 +1,6 @@
 package org.semagrow.query.impl;
 
-import org.semagrow.art.LogUtils;
+import org.semagrow.art.Loggable;
 import org.semagrow.query.SemagrowTupleQuery;
 import org.semagrow.sail.SemagrowSailConnection;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
@@ -71,6 +71,12 @@ public class SemagrowSailTupleQuery extends SemagrowSailQuery implements Semagro
         logger.info("SemaGrow query evaluate with handler {}", this.queryString.replace('\n',' '));
         TupleExpr tupleExpr = getParsedQuery().getTupleExpr();
 
+        evaluate(tupleExpr, handler);
+    }
+
+    @Loggable
+    public void evaluate(TupleExpr tupleExpr, TupleQueryResultHandler handler)
+            throws QueryEvaluationException, TupleQueryResultHandlerException {
         try {
             Publisher<? extends BindingSet> result;
 
@@ -81,8 +87,6 @@ public class SemagrowSailTupleQuery extends SemagrowSailQuery implements Semagro
                     getIncludedSources(), getExcludedSources());
 
             //result = enforceMaxQueryTime(bindingsIter);
-
-            logger.info("[{}] Query evaluation Start.", LogUtils.getQueryID());
 
             CountDownLatch latch = new CountDownLatch(1);
 
@@ -102,8 +106,6 @@ public class SemagrowSailTupleQuery extends SemagrowSailQuery implements Semagro
                 else
                     throw new QueryEvaluationException(subscriberAdapter.errorThrown);
             }
-
-            logger.info("[{}] Query evaluation End.", LogUtils.getQueryID());
         }
         catch (SailException e) {
             throw new QueryEvaluationException(e.getMessage(), e);

--- a/rdf4j/src/main/java/org/semagrow/query/impl/SemagrowSailTupleQuery.java
+++ b/rdf4j/src/main/java/org/semagrow/query/impl/SemagrowSailTupleQuery.java
@@ -1,5 +1,6 @@
 package org.semagrow.query.impl;
 
+import org.semagrow.art.LogUtils;
 import org.semagrow.query.SemagrowTupleQuery;
 import org.semagrow.sail.SemagrowSailConnection;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
@@ -14,6 +15,7 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import sun.rmi.runtime.Log;
 
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
@@ -103,7 +105,10 @@ public class SemagrowSailTupleQuery extends SemagrowSailQuery implements Semagro
             }
 
             long duration = System.currentTimeMillis() - start;
-            logger.info( "execution time: {}", duration);
+            LogUtils.appendKobeReport("Execution time: " + duration);
+
+            logger.debug( "execution time: {}", duration);
+            logger.info(LogUtils.getKobeReport());
         }
         catch (SailException e) {
             throw new QueryEvaluationException(e.getMessage(), e);

--- a/rdf4j/src/main/java/org/semagrow/query/impl/SemagrowSailTupleQuery.java
+++ b/rdf4j/src/main/java/org/semagrow/query/impl/SemagrowSailTupleQuery.java
@@ -1,6 +1,5 @@
 package org.semagrow.query.impl;
 
-import org.semagrow.art.Loggable;
 import org.semagrow.query.SemagrowTupleQuery;
 import org.semagrow.sail.SemagrowSailConnection;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
@@ -61,22 +60,16 @@ public class SemagrowSailTupleQuery extends SemagrowSailQuery implements Semagro
     }
 
     public void evaluate(TupleQueryResultHandler handler)
-            throws QueryEvaluationException, TupleQueryResultHandlerException
+            throws QueryEvaluationException, TupleQueryResultHandlerException 
     {
         /*
         TupleQueryResult queryResult = evaluate();
         QueryResults.report(queryResult, handler);
         */
 
-        logger.info("SemaGrow query evaluate with handler {}", this.queryString.replace('\n',' '));
+        logger.info("Evaluate query with handler");
         TupleExpr tupleExpr = getParsedQuery().getTupleExpr();
 
-        evaluate(tupleExpr, handler);
-    }
-
-    @Loggable
-    public void evaluate(TupleExpr tupleExpr, TupleQueryResultHandler handler)
-            throws QueryEvaluationException, TupleQueryResultHandlerException {
         try {
             Publisher<? extends BindingSet> result;
 
@@ -87,6 +80,8 @@ public class SemagrowSailTupleQuery extends SemagrowSailQuery implements Semagro
                     getIncludedSources(), getExcludedSources());
 
             //result = enforceMaxQueryTime(bindingsIter);
+
+            logger.info( "Enter execute");
 
             CountDownLatch latch = new CountDownLatch(1);
 
@@ -106,6 +101,8 @@ public class SemagrowSailTupleQuery extends SemagrowSailQuery implements Semagro
                 else
                     throw new QueryEvaluationException(subscriberAdapter.errorThrown);
             }
+
+            logger.info( "Exit  execute");
         }
         catch (SailException e) {
             throw new QueryEvaluationException(e.getMessage(), e);
@@ -157,12 +154,12 @@ public class SemagrowSailTupleQuery extends SemagrowSailQuery implements Semagro
                         handler.startQueryResult(new ArrayList<>(bindings.getBindingNames()));
                     }
                     isStarted = true;
-                    logger.info("Found first result.");
+                    logger.info("Found first result");
                 }
                 synchronized (handler) {
                     handler.handleSolution(bindings);
                 }
-                logger.info("-> Found " + bindings);
+                logger.info("Found {}", bindings);
                 resultsCount++;
             } catch (TupleQueryResultHandlerException e) {
                 subscription.cancel();
@@ -201,7 +198,7 @@ public class SemagrowSailTupleQuery extends SemagrowSailQuery implements Semagro
 
 
         public void onComplete() {
-            logger.info("Found " + resultsCount + " results.");
+            logger.info("Found {} results", resultsCount);
             if (isStarted) {
                 try {
                     synchronized (handler) {

--- a/rdf4j/src/main/java/org/semagrow/sail/SemagrowSail.java
+++ b/rdf4j/src/main/java/org/semagrow/sail/SemagrowSail.java
@@ -138,12 +138,13 @@ public class SemagrowSail extends AbstractSail {
         TupleQueryResultWriterRegistry  registry = TupleQueryResultWriterRegistry.getInstance();
         TupleQueryResultWriterFactory writerFactory = registry.get(resultFF).get();
         materializationManager = new FileManager(baseDir, writerFactory);
-
+        /*
         try {
             return factory.getQueryRecordLogger(config);
         } catch (QueryLogException e) {
             logger.warn("Cannot initialize Query Log writer", e);
         }
+        */
         return null;
     }
 

--- a/rdf4j/src/main/java/org/semagrow/sail/SemagrowSailConnection.java
+++ b/rdf4j/src/main/java/org/semagrow/sail/SemagrowSailConnection.java
@@ -132,7 +132,7 @@ public class SemagrowSailConnection extends AbstractSailConnection {
         decomposed = decompose(tupleExpr, dataset, bindings, includeOnlySources, excludeSources);
 
         logger.debug("Query decomposed to " + decomposed.toString());
-        logger.info("Decomposed query: " + decomposed.toString());
+        logger.info("Decomposed query: \n" + decomposed.toString());
 
         throw new SailException("Closeableiteration is not implemented. Please use the queryhandler");
         //return evaluateOnly(decomposed, dataset, bindings, b, p);

--- a/sparql/src/main/java/org/semagrow/connector/sparql/execution/ConnectionManager.java
+++ b/sparql/src/main/java/org/semagrow/connector/sparql/execution/ConnectionManager.java
@@ -47,7 +47,7 @@ public class ConnectionManager {
             repo.initialize();
 
         RepositoryConnection conn = repo.getConnection();
-        logger.info("Open [{}] (currently open={})", conn, countconn);
+        logger.debug("Open [{}] (currently open={})", conn, countconn);
         synchronized(this) { countconn++; }
         return conn;
     }
@@ -57,7 +57,7 @@ public class ConnectionManager {
             if (conn.isOpen()) {
                 conn.close();
                 synchronized (this) { countconn--; }
-                logger.info("Close [{}]", conn);
+                logger.debug("Close [{}]", conn);
             }
         } catch (RepositoryException e) {
             logger.warn("Connection [{}] cannot be closed", conn, e);

--- a/sparql/src/main/java/org/semagrow/connector/sparql/execution/SPARQLQueryExecutor.java
+++ b/sparql/src/main/java/org/semagrow/connector/sparql/execution/SPARQLQueryExecutor.java
@@ -250,6 +250,7 @@ public class SPARQLQueryExecutor extends ConnectionManager implements QueryExecu
             query.setBinding(b.getName(), b.getValue());
 
         LoggingUtil.logRemote(logger, conn, sparqlQuery, endpoint, expr, query);
+        logger.info("Sending to {} query {} with {}", endpoint, sparqlQuery, bindings);
 
         return Flux.from(new TupleQueryResultPublisher(query, sparqlQuery, qfrHandler, mat, endpoint))
                 .doAfterTerminate(() -> closeQuietly(conn));
@@ -278,6 +279,7 @@ public class SPARQLQueryExecutor extends ConnectionManager implements QueryExecu
             query.setBinding(b.getName(), b.getValue());
 
         LoggingUtil.logRemote(logger, conn, sparqlQuery, endpoint, expr, query);
+        logger.info("Sending to {} query {} with {}", endpoint, sparqlQuery, bindings);
 
         boolean answer = query.evaluate();
         closeQuietly(conn);

--- a/sparql/src/main/java/org/semagrow/connector/sparql/execution/SPARQLQueryExecutor.java
+++ b/sparql/src/main/java/org/semagrow/connector/sparql/execution/SPARQLQueryExecutor.java
@@ -250,7 +250,7 @@ public class SPARQLQueryExecutor extends ConnectionManager implements QueryExecu
             query.setBinding(b.getName(), b.getValue());
 
         LoggingUtil.logRemote(logger, conn, sparqlQuery, endpoint, expr, query);
-        logger.info("Sending to {} query {} with {}", endpoint, sparqlQuery, bindings);
+        logger.info("Sending query {} to {} with {}", sparqlQuery, endpoint, bindings);
 
         return Flux.from(new TupleQueryResultPublisher(query, sparqlQuery, qfrHandler, mat, endpoint))
                 .doAfterTerminate(() -> closeQuietly(conn));
@@ -279,7 +279,7 @@ public class SPARQLQueryExecutor extends ConnectionManager implements QueryExecu
             query.setBinding(b.getName(), b.getValue());
 
         LoggingUtil.logRemote(logger, conn, sparqlQuery, endpoint, expr, query);
-        logger.info("Sending to {} query {} with {}", endpoint, sparqlQuery, bindings);
+        logger.info("Sending query {} to {} with {}", sparqlQuery, endpoint, bindings);
 
         boolean answer = query.evaluate();
         closeQuietly(conn);

--- a/sparql/src/main/java/org/semagrow/connector/sparql/execution/TupleQueryResultPublisher.java
+++ b/sparql/src/main/java/org/semagrow/connector/sparql/execution/TupleQueryResultPublisher.java
@@ -10,7 +10,6 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 
 import java.net.URL;
 import java.util.List;

--- a/sparql/src/main/java/org/semagrow/connector/sparql/selector/AskSourceSelector.java
+++ b/sparql/src/main/java/org/semagrow/connector/sparql/selector/AskSourceSelector.java
@@ -1,6 +1,5 @@
 package org.semagrow.connector.sparql.selector;
 
-import org.semagrow.art.Loggable;
 import org.semagrow.selector.Site;
 import org.semagrow.selector.SourceMetadata;
 import org.semagrow.selector.SourceSelector;
@@ -111,7 +110,6 @@ public class AskSourceSelector extends SourceSelectorWrapper implements SourceSe
 	 * @param list The list of candidate data sources
 	 * @return The subset of the data sources in list that contain triples matching the pattern
 	 */
-	 @Loggable
 	 private Collection<SourceMetadata> restrictSourceList( StatementPattern pattern, Collection<SourceMetadata> list )
 	 {
 		 Collection<SourceMetadata> restrictedList = new LinkedList<SourceMetadata>();


### PR DESCRIPTION
Updates:

- The configuration file of logback (logback.groovy) is placed in proper location inside the SemaGrow.war so that logback is correctly configured. In the current configuration only INFO log messages are visible.
- INFO logging now outputs only the following messages (all other existing log messages are pushed down into DEBUG):
  1. Initial query string that arrives in the http controller
  2. The resulting plan of the query planner.
  3. The source queries that the query execution engine issues in the endpoints.
  4. Query statistics specific for the kobe engine: this log message is printed at the end of the query evaluation and contains the following information:
      1. Query metadata from kobe engine (if such information exists). Kobe attaches such metadata using a comment of the form `#kobeQueryDesc METADATA` in the first line of the input query string. This mechanism is used to connect a kobe query run with the corresponding semagrow query run.
     2. Duration query planning in milliseconds.
     3. Duration of the query source selection in milliseconds.
     4. Duration of the query execution in milliseconds.
     5. The number of the sources that the query plan requires.
- Each log message depicts its timestamp and a UUID that links the message with the relevant query (i.e., all messages that have the same UUID correspond to the same query evaluation). 
