### PR TITLE
Fixes on prefix-based source selection

### DIFF
--- a/core/src/main/java/org/semagrow/selector/PrefixBase.java
+++ b/core/src/main/java/org/semagrow/selector/PrefixBase.java
@@ -80,24 +80,7 @@ public class PrefixBase {
                 return result;
             }
         }
-
-        Variable prefix = SparqlBuilder.var("prefix");
-        Variable d = SparqlBuilder.var("d");
-
-        TriplePattern t1 = d.has(RDF.TYPE, VOID.DATASET);
-        TriplePattern t2 = d.has(VOID.SPARQLENDPOINT, endpoint);
-        TriplePattern t3 = d.has(SEVOD.SUBJECTREGEXPATTERN, prefix);
-
-        GraphPattern body = GraphPatterns.and(t1,t2,t3);
-
-        SelectQuery selectQuery = Queries.SELECT().select(prefix).where(body);
-
-        Collection<String> result = runQuery(selectQuery.getQueryString());
-
-        if (!result.isEmpty()) {
-            return result;
-        }
-        return Collections.singletonList("");
+        return Collections.singletonList("ΑΝΥ");
     }
 
     public Collection<String> getObjectRegexPattern(StatementPattern pattern, Resource endpoint) {
@@ -126,24 +109,7 @@ public class PrefixBase {
                 return result;
             }
         }
-
-        Variable prefix = SparqlBuilder.var("prefix");
-        Variable d = SparqlBuilder.var("d");
-
-        TriplePattern t1 = d.has(RDF.TYPE, VOID.DATASET);
-        TriplePattern t2 = d.has(VOID.SPARQLENDPOINT, endpoint);
-        TriplePattern t3 = d.has(SEVOD.OBJECTREGEXPATTERN, prefix);
-
-        GraphPattern body = GraphPatterns.and(t1,t2,t3);
-
-        SelectQuery selectQuery = Queries.SELECT().select(prefix).where(body);
-
-        Collection<String> result = runQuery(selectQuery.getQueryString());
-
-        if (!result.isEmpty()) {
-            return result;
-        }
-        return Collections.singletonList("");
+        return Collections.singletonList("ΑΝΥ");
     }
 
     private Collection<String> runQuery(String qStr){

--- a/core/src/main/java/org/semagrow/selector/PrefixQueryAwareSourceSelector.java
+++ b/core/src/main/java/org/semagrow/selector/PrefixQueryAwareSourceSelector.java
@@ -10,6 +10,7 @@ import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
 import org.eclipse.rdf4j.repository.Repository;
 import org.semagrow.plan.Pair;
 import org.semagrow.plan.util.BPGCollector;
+import org.semagrow.util.GroupedPatternCollector;
 
 import java.util.*;
 
@@ -32,18 +33,18 @@ public class PrefixQueryAwareSourceSelector extends SourceSelectorWrapper implem
         if (getWrappedSelector() instanceof QueryAwareSourceSelector) {
             ((QueryAwareSourceSelector) getWrappedSelector()).processTupleExpr(expr);
         }
-        Collection<TupleExpr> bpgs = BPGCollector.process(expr);
-        for (TupleExpr bpg: bpgs) {
-            processBPG(bpg);
+        Collection<List<StatementPattern>> groups = GroupedPatternCollector.process(expr);
+        for (List<StatementPattern> group: groups) {
+            processBPG(group);
         }
         processed = true;
     }
 
-    private void processBPG(TupleExpr expr) {
+    private void processBPG(List<StatementPattern> group) {
 
         Map<StatementPattern,Map<SourceMetadata,Map<String,Collection<String>>>> phatMap = new HashMap<>();
 
-        for (StatementPattern pattern:  StatementPatternCollector.process(expr)) {
+        for (StatementPattern pattern: group) {
             Map<SourceMetadata,Map<String,Collection<String>>> sourceMap = new HashMap<>();
 
             for (SourceMetadata source: getWrappedSelector().getSources(pattern, null, EmptyBindingSet.getInstance())) {

--- a/core/src/main/java/org/semagrow/util/GroupedPatternCollector.java
+++ b/core/src/main/java/org/semagrow/util/GroupedPatternCollector.java
@@ -1,5 +1,6 @@
 package org.semagrow.util;
 
+import org.eclipse.rdf4j.query.algebra.Exists;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.Union;
@@ -13,6 +14,7 @@ import java.util.List;
 public class GroupedPatternCollector extends AbstractQueryModelVisitor<RuntimeException> {
 
     private Collection<List<StatementPattern>> groups = new ArrayList<>();
+    private Collection<List<StatementPattern>> additionalGroups = new ArrayList<>();
 
     private GroupedPatternCollector() { }
 
@@ -22,6 +24,7 @@ public class GroupedPatternCollector extends AbstractQueryModelVisitor<RuntimeEx
         if (collector.groups.isEmpty()) {
             collector.addGroup(StatementPatternCollector.process(expr));
         }
+        collector.groups.addAll(collector.additionalGroups);
         return collector.groups;
     }
 
@@ -44,6 +47,11 @@ public class GroupedPatternCollector extends AbstractQueryModelVisitor<RuntimeEx
         else  {
             groups.add(StatementPatternCollector.process(r));
         }
+    }
+
+    @Override
+    public void meet(Exists node) throws RuntimeException {
+        additionalGroups.add(StatementPatternCollector.process(node.getSubQuery()));
     }
 
     public void addGroup(List<StatementPattern> group) {

--- a/core/src/main/java/org/semagrow/util/GroupedPatternCollector.java
+++ b/core/src/main/java/org/semagrow/util/GroupedPatternCollector.java
@@ -1,0 +1,52 @@
+package org.semagrow.util;
+
+import org.eclipse.rdf4j.query.algebra.StatementPattern;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.Union;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
+import org.eclipse.rdf4j.query.algebra.helpers.StatementPatternCollector;
+
+import java.util.Collection;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GroupedPatternCollector extends AbstractQueryModelVisitor<RuntimeException> {
+
+    private Collection<List<StatementPattern>> groups = new ArrayList<>();
+
+    private GroupedPatternCollector() { }
+
+    public static Collection<List<StatementPattern>> process(TupleExpr expr){
+        GroupedPatternCollector collector = new GroupedPatternCollector();
+        expr.visit(collector);
+        if (collector.groups.isEmpty()) {
+            collector.addGroup(StatementPatternCollector.process(expr));
+        }
+        return collector.groups;
+    }
+
+    @Override
+    public void meet(Union node) throws RuntimeException {
+
+        TupleExpr l = node.getLeftArg();
+        TupleExpr r = node.getRightArg();
+
+        if (l instanceof Union) {
+            l.visit(this);
+        }
+        else  {
+            groups.add(StatementPatternCollector.process(l));
+        }
+
+        if (r instanceof Union) {
+            r.visit(this);
+        }
+        else  {
+            groups.add(StatementPatternCollector.process(r));
+        }
+    }
+
+    public void addGroup(List<StatementPattern> group) {
+        groups.add(group);
+    }
+}


### PR DESCRIPTION
Updates:
 * Created a custom group pattern connector (instead of using BPGCollector) for collecting all triple patterns of the query.
Now the triple patterns in complex queries are not ignored (fixes #56).
 * Removed redundant queries for global subject and object prefixes issued by the source selector in metadata.
