### PR TITLE
Semagrow Web GUI now outputs query results

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,17 +8,27 @@ WORKDIR /semagrow
 
 COPY . /semagrow
 
-RUN --mount=type=cache,target=/root/.m2 mvn clean install
+RUN --mount=type=cache,target=/root/.m2 mvn clean package -P tomcat-bundle
 
 
-FROM tomcat:8.5-jre8-alpine
+FROM openjdk:8-jre-alpine
+
+ENV SEMAGROW_HOME /opt/semagrow
+ENV CATALINA_HOME $SEMAGROW_HOME
+ENV PATH $CATALINA_HOME/bin:$PATH
 
 RUN mkdir -p /etc/default/semagrow
 
 COPY --from=build /semagrow/assembly/src/main/resources/metadata.ttl /etc/default/semagrow/
 COPY --from=build /semagrow/assembly/src/main/resources/repository.ttl /etc/default/semagrow
 
-COPY --from=build /semagrow/webgui/target/SemaGrow.war $CATALINA_HOME/webapps/SemaGrow.war
+COPY --from=build semagrow/assembly/target/semagrow-*-tomcat-bundle.tar.gz semagrow-tomcat.tar.gz
+
+RUN mkdir -p $SEMAGROW_HOME \
+ && tar zxvf semagrow-tomcat.tar.gz -C $SEMAGROW_HOME \
+ && rm semagrow-tomcat.tar.gz
+
+WORKDIR $SEMAGROW_HOME
 
 EXPOSE 8080
 


### PR DESCRIPTION
Modify Dockerfile such that to create a pre-bundled build with tomcat.
Now the results are displayed correctly.
Related to #61 