### PR TITLE
Updates in Semagrow optimizer

### DIFF
--- a/core/src/main/java/org/semagrow/estimator/SimpleCardinalityEstimator.java
+++ b/core/src/main/java/org/semagrow/estimator/SimpleCardinalityEstimator.java
@@ -107,7 +107,8 @@ public class SimpleCardinalityEstimator implements CardinalityEstimator {
 
         BigInteger card2 = getCardinality(join.getRightArg());
 
-        BigDecimal sel = BigDecimal.valueOf(selectivityEstimator.getJoinSelectivity(join));
+        Double js = selectivityEstimator.getJoinSelectivity(join);
+        BigDecimal sel = (js.isInfinite()) ? BigDecimal.valueOf(Double.MAX_VALUE) : BigDecimal.valueOf(js);
 
         BigInteger tt = new BigDecimal(card1.multiply(card2)).multiply(sel).setScale(0, RoundingMode.CEILING).toBigInteger();
 

--- a/core/src/main/java/org/semagrow/plan/SimpleQueryCompiler.java
+++ b/core/src/main/java/org/semagrow/plan/SimpleQueryCompiler.java
@@ -12,6 +12,8 @@ import org.semagrow.art.Loggable;
 import org.semagrow.estimator.CardinalityEstimatorResolver;
 import org.semagrow.estimator.CostEstimatorResolver;
 import org.semagrow.local.LocalSite;
+import org.semagrow.plan.optimizer.BindJoinExtensionOptimizer;
+import org.semagrow.plan.optimizer.ExtensionOptimizer;
 import org.semagrow.plan.optimizer.FilterPlanOptimizer;
 import org.semagrow.plan.queryblock.*;
 import org.semagrow.plan.util.EndpointCollector;
@@ -133,7 +135,8 @@ public class SimpleQueryCompiler implements QueryCompiler {
     protected void optimize(TupleExpr expr, Dataset dataset, BindingSet bindings) {
 
         QueryOptimizer queryOptimizer =  new QueryOptimizerList(
-                new FilterPlanOptimizer()
+                new FilterPlanOptimizer(),
+                new BindJoinExtensionOptimizer()
         );
 
         queryOptimizer.optimize(expr, dataset, bindings);

--- a/core/src/main/java/org/semagrow/plan/SimpleQueryCompiler.java
+++ b/core/src/main/java/org/semagrow/plan/SimpleQueryCompiler.java
@@ -13,7 +13,6 @@ import org.semagrow.estimator.CardinalityEstimatorResolver;
 import org.semagrow.estimator.CostEstimatorResolver;
 import org.semagrow.local.LocalSite;
 import org.semagrow.plan.optimizer.BindJoinExtensionOptimizer;
-import org.semagrow.plan.optimizer.ExtensionOptimizer;
 import org.semagrow.plan.optimizer.FilterPlanOptimizer;
 import org.semagrow.plan.queryblock.*;
 import org.semagrow.plan.util.EndpointCollector;

--- a/core/src/main/java/org/semagrow/plan/operators/BindNotExists.java
+++ b/core/src/main/java/org/semagrow/plan/operators/BindNotExists.java
@@ -1,0 +1,26 @@
+package org.semagrow.plan.operators;
+
+import org.eclipse.rdf4j.query.algebra.Join;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+
+public class BindNotExists extends Join {
+
+    public BindNotExists(TupleExpr e1, TupleExpr e2) {
+        super(e1,e2);
+    }
+
+    @Override
+    public int hashCode() {
+        return "bind-not-exists".hashCode() + super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof BindNotExists) {
+            BindNotExists j = (BindNotExists) o;
+            return getLeftArg().equals(j.getLeftArg()) && getRightArg().equals(j.getRightArg());
+        }
+        return false;
+    }
+}
+

--- a/core/src/main/java/org/semagrow/plan/optimizer/BindJoinExtensionOptimizer.java
+++ b/core/src/main/java/org/semagrow/plan/optimizer/BindJoinExtensionOptimizer.java
@@ -1,0 +1,178 @@
+package org.semagrow.plan.optimizer;
+
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.algebra.*;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
+import org.eclipse.rdf4j.query.algebra.helpers.VarNameCollector;
+import org.semagrow.plan.Plan;
+import org.semagrow.plan.operators.BindJoin;
+import org.semagrow.plan.operators.HashJoin;
+import org.semagrow.plan.operators.MergeJoin;
+import org.semagrow.plan.operators.SourceQuery;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class BindJoinExtensionOptimizer implements QueryOptimizer {
+    @Override
+    public void optimize(TupleExpr tupleExpr, Dataset dataset, BindingSet bindingSet) {
+        tupleExpr.visit(new ExtensionFinder(tupleExpr));
+    }
+
+    protected static class ExtensionFinder extends AbstractQueryModelVisitor<RuntimeException> {
+        protected final TupleExpr tupleExpr;
+
+        public ExtensionFinder(TupleExpr tupleExpr) {
+            this.tupleExpr = tupleExpr;
+        }
+
+        public void meet(Extension node) {
+            super.meet(node);
+            ExtensionRelocator.relocate(node);
+        }
+    }
+
+    protected static class ExtensionRelocator extends AbstractQueryModelVisitor<RuntimeException> {
+        protected final Extension extension;
+        protected final Set<String> vars;
+
+        public static void relocate(Extension extension) {
+            extension.visit(new ExtensionRelocator(extension));
+        }
+
+        public ExtensionRelocator(Extension extension) {
+            this.extension = extension;
+            vars = new HashSet<>();
+
+            for (ExtensionElem e : extension.getElements()) {
+                vars.addAll(VarNameCollector.process(e.getExpr()));
+            }
+        }
+
+        protected void meetNode(QueryModelNode node) {
+            assert node instanceof TupleExpr;
+
+            this.relocate(this.extension, (TupleExpr) node);
+        }
+
+        public void meet(SourceQuery node) {
+            this.relocate(this.extension, node.getArg());
+        }
+
+        public void meet(Join join) {
+            if (join instanceof BindJoin) {
+                if (join.getLeftArg().getBindingNames().containsAll(this.vars)) {
+                    join.getLeftArg().visit(this);
+                } else {
+                    join.getRightArg().visit(this);
+                }
+            }
+            else {
+                if (join.getLeftArg().getBindingNames().containsAll(this.vars)) {
+                    join.getLeftArg().visit(this);
+                } else if (join.getRightArg().getBindingNames().containsAll(this.vars)) {
+                    join.getRightArg().visit(this);
+                } else {
+                    this.relocate(this.extension, join);
+                }
+            }
+        }
+
+        public void meet(LeftJoin leftJoin) {
+            if (leftJoin.getLeftArg().getBindingNames().containsAll(this.vars)) {
+                leftJoin.getLeftArg().visit(this);
+            } else {
+                this.relocate(this.extension, leftJoin);
+            }
+        }
+
+        public void meet(Union union) {
+            Extension clone = new Extension();
+            clone.setElements(extension.getElements());
+            this.relocate(this.extension, union.getLeftArg());
+            this.relocate(clone, union.getRightArg());
+            relocate(this.extension);
+            relocate(clone);
+        }
+
+        public void meet(Difference node) {
+            Extension clone = new Extension();
+            clone.setElements(extension.getElements());
+            this.relocate(this.extension, node.getLeftArg());
+            this.relocate(clone, node.getRightArg());
+            relocate(this.extension);
+            relocate(clone);
+        }
+
+        public void meet(Intersection node) {
+            Extension clone = new Extension();
+            clone.setElements(extension.getElements());
+            this.relocate(this.extension, node.getLeftArg());
+            this.relocate(clone, node.getRightArg());
+            relocate(this.extension);
+            relocate(clone);
+        }
+
+        public void meet(Extension node) {
+            if (node.getArg().getBindingNames().containsAll(this.vars)) {
+                node.getArg().visit(this);
+            } else {
+                this.relocate(this.extension, node);
+            }
+        }
+
+        public void meet(EmptySet node) {
+            if (this.extension.getParentNode() != null) {
+                this.extension.replaceWith(this.extension.getArg());
+            }
+        }
+
+        public void meet(Filter filter) {
+            filter.getArg().visit(this);
+        }
+
+        public void meet(Distinct node) {
+            node.getArg().visit(this);
+        }
+
+        public void meet(Order node) {
+            node.getArg().visit(this);
+        }
+
+        public void meet(QueryRoot node) {
+            node.getArg().visit(this);
+        }
+
+        public void meet(Reduced node) {
+            node.getArg().visit(this);
+        }
+
+        @Override
+        public void meetOther(QueryModelNode node) {
+            if (node instanceof Plan)
+                ((Plan) node).getArg().visit(this);
+            else if (node instanceof BindJoin)
+                meet((Join)node);
+            else if (node instanceof HashJoin)
+                meet((Join)node);
+            else if (node instanceof MergeJoin)
+                meet((Join)node);
+            else if (node instanceof SourceQuery)
+                meet((SourceQuery)node);
+            else
+                meetNode(node);
+        }
+
+        protected void relocate(Extension extension, TupleExpr newArg) {
+            if (extension.getArg() != newArg) {
+                if (extension.getParentNode() != null) {
+                    extension.replaceWith(extension.getArg());
+                }
+                newArg.replaceWith(extension);
+                extension.setArg(newArg);
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/semagrow/plan/optimizer/BindJoinExtensionOptimizer.java
+++ b/core/src/main/java/org/semagrow/plan/optimizer/BindJoinExtensionOptimizer.java
@@ -129,6 +129,16 @@ public class BindJoinExtensionOptimizer implements QueryOptimizer {
             }
         }
 
+        @Override
+        public void meet(Projection node) throws RuntimeException {
+            node.getArg().visit(this);
+        }
+
+        @Override
+        public void meet(Slice node) throws RuntimeException {
+            node.getArg().visit(this);
+        }
+
         public void meet(Filter filter) {
             filter.getArg().visit(this);
         }

--- a/core/src/main/java/org/semagrow/plan/queryblock/SelectBlock.java
+++ b/core/src/main/java/org/semagrow/plan/queryblock/SelectBlock.java
@@ -7,6 +7,7 @@ import org.semagrow.plan.*;
 import org.semagrow.plan.operators.*;
 import org.semagrow.selector.Site;
 import org.semagrow.util.CombinationIterator;
+import org.semagrow.util.FilterNotExistsCombinator;
 import org.semagrow.util.PartitionedSet;
 
 import java.util.*;
@@ -444,6 +445,20 @@ public class SelectBlock extends AbstractQueryBlock {
             Collection<Quantifier> all = new HashSet<>(left.getFirst().size() + right.getFirst().size());
             all.addAll(left.getFirst());
             all.addAll(right.getFirst());
+
+            ///////////
+            // FIXME: Workaround for filter not exists:
+            ///////////
+            if (FilterNotExistsCombinator.match(left, right)) {
+                Collection<Plan> plans = FilterNotExistsCombinator.combine(left, right, context);
+                return new Pair<>(all, plans);
+            }
+            if (FilterNotExistsCombinator.match(right, left)) {
+                Collection<Plan> plans = FilterNotExistsCombinator.combine(right, left, context);
+                return new Pair<>(all, plans);
+            }
+            ///////////
+
             Collection<Plan> plans = crossProduct(left, right);
             return new Pair<>(all, plans);
         }

--- a/core/src/main/java/org/semagrow/plan/queryblock/SelectBlock.java
+++ b/core/src/main/java/org/semagrow/plan/queryblock/SelectBlock.java
@@ -77,6 +77,8 @@ public class SelectBlock extends AbstractQueryBlock {
 
     public void setOffset(Long l) { offset = Optional.of(l); }
 
+    public Optional<Long> getLimit() { return limit; }
+
     @Override
     public <X extends Exception> void visitChildren(QueryBlockVisitor<X> visitor) throws X {
         for (Quantifier q : quantifiers)

--- a/core/src/main/java/org/semagrow/plan/queryblock/SelectMergeVisitor.java
+++ b/core/src/main/java/org/semagrow/plan/queryblock/SelectMergeVisitor.java
@@ -39,7 +39,9 @@ public class SelectMergeVisitor extends AbstractQueryBlockVisitor<RuntimeExcepti
             boolean ordering = lower.getOutputDataProperties().hasOrdering() &&
                                !upper.getOutputDataProperties().hasOrdering();
 
-            return duplicateConstraint && !ordering;
+            boolean limit = !lower.getLimit().isPresent() && !upper.getLimit().isPresent();
+
+            return duplicateConstraint && !ordering && limit;
         }
 
         return false;

--- a/core/src/main/java/org/semagrow/statistics/VOIDStatistics.java
+++ b/core/src/main/java/org/semagrow/statistics/VOIDStatistics.java
@@ -77,6 +77,9 @@ public class VOIDStatistics extends VOIDBase implements Statistics {
         spDatasets.retainAll(sDatasets);
 
         if (!spDatasets.isEmpty()) { // datasets that match both the predicate and subject
+            if (sVal != null && pVal != null & getDistinctSubjects(spDatasets).equals(getTriplesCount(sDatasets))) {
+                return 1;
+            }
             long d = 1;
             if (oVal != null)
                 d = getDistinctObjects(spDatasets);

--- a/core/src/main/java/org/semagrow/util/BindJoinExtensionHandler.java
+++ b/core/src/main/java/org/semagrow/util/BindJoinExtensionHandler.java
@@ -1,0 +1,69 @@
+package org.semagrow.util;
+
+import org.eclipse.rdf4j.query.algebra.*;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
+import org.semagrow.plan.Plan;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class BindJoinExtensionHandler {
+
+    private static Set<Extension> extensions = new HashSet<>();
+
+    public void extractExtensions(TupleExpr tupleExpr) {
+        tupleExpr.visit(new ExtensionExtractor());
+    }
+
+    public void placeExtenstions(TupleExpr tupleExpr) {
+        for (Extension extension: extensions) {
+            ExtensionPlacer.place(tupleExpr, extension);
+        }
+    }
+
+    protected static class ExtensionExtractor extends AbstractQueryModelVisitor<RuntimeException> {
+
+        public void meet(Extension extension) {
+            super.meet(extension);
+            Extension e = extension.clone();
+            e.setArg(new EmptySet());
+            extensions.add(e);
+        }
+    }
+
+    protected static class ExtensionPlacer extends AbstractQueryModelVisitor<RuntimeException> {
+        private TupleExpr queryRoot;
+        private Extension extension;
+        private boolean placed = false;
+
+        public static void place(TupleExpr tupleExpr, Extension extension) {
+            QueryRoot queryRoot = new QueryRoot();
+            queryRoot.setArg(tupleExpr);
+            queryRoot.visit(new ExtensionPlacer(extension));
+        }
+
+        public ExtensionPlacer(Extension extension) {
+            this.extension = extension;
+        }
+
+        public void meet(Extension extension) {
+            super.meet(extension);
+            if (this.extension.getElements().equals(extension.getElements())) {
+                placed = true;
+            }
+        }
+
+        @Override
+        public void meet(QueryRoot queryRoot) throws RuntimeException {
+            super.meet(queryRoot);
+            if (!placed) {
+                assert queryRoot.getArg() instanceof Plan;
+
+                Plan rootPlan = (Plan) queryRoot.getArg();
+                extension.setParentNode(rootPlan);
+                extension.setArg(rootPlan.getArg());
+                rootPlan.setArg(extension);
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/semagrow/util/FilterNotExistsCombinator.java
+++ b/core/src/main/java/org/semagrow/util/FilterNotExistsCombinator.java
@@ -1,0 +1,51 @@
+package org.semagrow.util;
+
+import org.semagrow.local.LocalSite;
+import org.semagrow.plan.*;
+import org.semagrow.plan.operators.BindNotExists;
+import org.semagrow.plan.queryblock.Quantifier;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+public class FilterNotExistsCombinator {
+
+    public static boolean match(Pair<Collection<Quantifier>, Collection<Plan>> left,
+                                Pair<Collection<Quantifier>, Collection<Plan>> right) {
+
+        if (left.getFirst().size() == 1 && right.getFirst().size() == 1) {
+            boolean lqflag = getQuantifier(left).getQuantification().equals(Quantifier.Quantification.EACH);
+            boolean rqflag = getQuantifier(right).getQuantification().equals(Quantifier.Quantification.ALL);
+
+            return lqflag && rqflag;
+        }
+        return false;
+    }
+
+    public static Collection<Plan> combine(Pair<Collection<Quantifier>, Collection<Plan>> left,
+                                           Pair<Collection<Quantifier>, Collection<Plan>> right,
+                                           CompilerContext context) {
+        Collection<Plan> collection = new HashSet<>();
+
+        RequestedPlanProperties props = new RequestedPlanProperties();
+        props.setSite(LocalSite.getInstance());
+        Collection<Plan> ppl = context.enforceProps(left.getSecond(), props);
+        Collection<Plan> ppr = context.enforceProps(right.getSecond(), props);
+
+        for (Plan l: ppl) {
+            for (Plan r: ppr) {
+                collection.add(context.asPlan(new BindNotExists(l,r)));
+            }
+        }
+        return collection;
+    }
+
+    private static Quantifier getQuantifier(Pair<Collection<Quantifier>, Collection<Plan>> pair) {
+        if (pair.getFirst().size() == 1) {
+            for (Quantifier q : pair.getFirst()) {
+                return q;
+            }
+        }
+        return null;
+    }
+}

--- a/core/src/main/java/org/semagrow/util/OrderPlanFixer.java
+++ b/core/src/main/java/org/semagrow/util/OrderPlanFixer.java
@@ -1,0 +1,92 @@
+package org.semagrow.util;
+
+import org.eclipse.rdf4j.query.algebra.*;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
+import org.semagrow.plan.Plan;
+import org.semagrow.plan.operators.BindJoin;
+import org.semagrow.plan.operators.HashJoin;
+import org.semagrow.plan.operators.MergeJoin;
+import org.semagrow.plan.operators.SourceQuery;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+public class OrderPlanFixer extends AbstractQueryModelVisitor<RuntimeException> {
+
+    public static void fixOrders(TupleExpr expr) {
+        expr.visit(new OrderPlanFixer());
+    }
+
+    public void meet(Order order) {
+        super.meet(order);
+
+        Collection<String> vars = VarNameCollector.process(order.getArg());
+        Collection<OrderElem> toRemove = new HashSet<>();
+
+        for (OrderElem elem: order.getElements()) {
+            if (elem.getExpr() instanceof Var) {
+                if (!vars.contains(((Var) elem.getExpr()).getName())) {
+                    toRemove.add(elem);
+                }
+            }
+        }
+        order.getElements().removeAll(toRemove);
+
+        if (order.getElements().isEmpty()) {
+            order.replaceWith(order.getArg());
+        }
+    }
+
+    private static class VarNameCollector extends AbstractQueryModelVisitor<RuntimeException> {
+        private Set<String> varNames = new HashSet();
+
+        public VarNameCollector() {
+        }
+
+        public static Set<String> process(QueryModelNode node) {
+            VarNameCollector collector = new VarNameCollector();
+            node.visit(collector);
+            return collector.getVarNames();
+        }
+
+        public Set<String> getVarNames() {
+            return this.varNames;
+        }
+
+        @Override
+        public void meet(Var var) {
+            if (!var.hasValue()) {
+                this.varNames.add(var.getName());
+            }
+        }
+
+        @Override
+        public void meet(ExtensionElem node) throws RuntimeException {
+            this.varNames.add(node.getName());
+        }
+
+        @Override
+        public void meetOther(QueryModelNode node) {
+            if (node instanceof Plan)
+                ((Plan) node).getArg().visit(this);
+            else if (node instanceof BindJoin)
+                meet((Join)node);
+            else if (node instanceof HashJoin)
+                meet((Join)node);
+            else if (node instanceof MergeJoin)
+                meet((Join)node);
+            else if (node instanceof SourceQuery)
+                meet((SourceQuery)node);
+            else
+                meetNode(node);
+        }
+
+        public void meet(SourceQuery node) {
+            node.getArg().visit(this);
+        }
+
+
+    }
+}
+

--- a/rdf4j/src/test/java/org/semagrow/test/CropsBenchTest.java
+++ b/rdf4j/src/test/java/org/semagrow/test/CropsBenchTest.java
@@ -1,0 +1,169 @@
+package org.semagrow.test;
+
+import org.eclipse.rdf4j.query.*;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
+import org.semagrow.cli.CliMain;
+import org.semagrow.query.SemagrowTupleQuery;
+import org.semagrow.repository.impl.SemagrowSailRepository;
+import org.semagrow.sail.SemagrowSail;
+import org.semagrow.sail.config.SemagrowSailConfig;
+import org.semagrow.sail.config.SemagrowSailFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CropsBenchTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(CliMain.class);
+
+    public static void main(String[] args) {
+
+        int lucas1[] = { 5245, 2887, 8653, 7357, 6112, 1768, 3939, 1618, 8518, 7203, 887, 6894, 4616 };
+        int lucas2[] = { 716, 2542, 8538, 8061 };
+        int lucas3[] = { 2266, 5798, 2091, 3114, 1193, 7768, 5046, 7708, 4413, 5451, 447 };
+
+        for (int i: lucas1) {
+            String[] argv = {"/tmp/repository.ttl", getQuery1(i), "/tmp/results-l1-" + i + ".json"};
+            CliMain.main(argv);
+            decompose(getQuery1(i));
+        }
+
+        for (int i: lucas2) {
+            String[] argv = {"/tmp/repository.ttl", getQuery2(i), "/tmp/results-l2-" + i + ".json"};
+            CliMain.main(argv);
+            decompose(getQuery2(i));
+        }
+
+        for (int i: lucas3) {
+            String[] argv = {"/tmp/repository.ttl", getQuery3(i), "/tmp/results-l3-" + i + ".json"};
+            CliMain.main(argv);
+            decompose(getQuery3(i));
+        }
+    }
+
+    public static void decompose(String queryString) {
+        try {
+            SemagrowSailFactory factory = new SemagrowSailFactory();
+            SemagrowSailConfig config = new SemagrowSailConfig();
+            Repository repository = new SemagrowSailRepository((SemagrowSail) factory.getSail(config));
+            repository.initialize();
+            RepositoryConnection conn = repository.getConnection();
+            TupleQuery query = conn.prepareTupleQuery(QueryLanguage.SPARQL, queryString);
+            TupleExpr plan = ((SemagrowTupleQuery) query).getDecomposedQuery();
+
+        } catch (RepositoryConfigException e) {
+            e.printStackTrace();
+        } catch (RepositoryException e) {
+            e.printStackTrace();
+        } catch (MalformedQueryException e) {
+            e.printStackTrace();
+        } catch (QueryEvaluationException e) {
+            e.printStackTrace();
+        } catch (TupleQueryResultHandlerException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static String getQuery1(int id) {
+        return "" +
+                "PREFIX lucas: <http://deg.iit.demokritos.gr/lucas/>\n" +
+                "PREFIX lucas_r: <http://deg.iit.demokritos.gr/lucas/resource/>\n" +
+                "PREFIX invekos: <http://deg.iit.demokritos.gr/invekos/>\n" +
+                "PREFIX lictm: <http://deg.iit.demokritos.gr/>\n" +
+                "PREFIX geof: <http://www.opengis.net/def/function/geosparql/>\n" +
+                "PREFIX geo: <http://www.opengis.net/ont/geosparql#>\n" +
+                "PREFIX opengis: <http://www.opengis.net/def/uom/OGC/1.0/>\n" +
+                "\n" +
+                "SELECT * WHERE {\n" +
+                "  {\n" +
+                "    SELECT * WHERE {\n" +
+                "      lucas_r:" + id + " geo:hasGeometry ?l_geom_id .\n" +
+                "      ?l_geom_id geo:asWKT ?l_geom .\n" +
+                "      ?inv invekos:hasCropTypeNumber ?i_ctype .\n" +
+                "      ?inv geo:hasGeometry ?i_geom_id .\n" +
+                "      ?i_geom_id geo:asWKT ?i_geom .\n" +
+                "      BIND(geof:distance(?l_geom,?i_geom,opengis:metre) as ?distance) .\n" +
+                "      FILTER(?distance < 10) .\n" +
+                "    }\n" +
+                "    ORDER BY ASC(?distance)\n" +
+                "    LIMIT 1\n" +
+                "  }\n" +
+                "  lucas_r:" + id + " lucas:hasLC1 ?lc1 .\n" +
+                "  lucas_r:" + id + " lucas:hasLC1_SPEC ?lc1_sp .\n" +
+                "  ?c lictm:lucasLC1 ?lc1 .\n" +
+                "  ?c lictm:lucasLC1_spec ?lc1_sp .\n" +
+                "  ?c lictm:invekosCropTypeNumber ?l_ctype .\n" +
+                "  FILTER(?l_ctype = ?i_ctype) .\n" +
+                "}";
+    }
+
+    public static String getQuery2(int id) {
+        return "" +
+                "PREFIX lucas: <http://deg.iit.demokritos.gr/lucas/>\n" +
+                "PREFIX lucas_r: <http://deg.iit.demokritos.gr/lucas/resource/>\n" +
+                "PREFIX invekos: <http://deg.iit.demokritos.gr/invekos/>\n" +
+                "PREFIX lictm: <http://deg.iit.demokritos.gr/>\n" +
+                "PREFIX geof: <http://www.opengis.net/def/function/geosparql/>\n" +
+                "PREFIX geo: <http://www.opengis.net/ont/geosparql#>\n" +
+                "PREFIX opengis: <http://www.opengis.net/def/uom/OGC/1.0/>\n" +
+                "SELECT * WHERE {\n" +
+                "  {\n" +
+                "    SELECT * WHERE {\n" +
+                "      lucas_r:" + id + " geo:hasGeometry ?l_geom_id .\n" +
+                "      ?l_geom_id geo:asWKT ?l_geom .\n" +
+                "      ?inv invekos:hasCropTypeNumber ?i_ctype .\n" +
+                "      ?inv geo:hasGeometry ?i_geom_id .\n" +
+                "      ?i_geom_id geo:asWKT ?i_geom .\n" +
+                "      BIND(geof:distance(?l_geom,?i_geom,opengis:metre) as ?distance) .\n" +
+                "      FILTER(?distance < 10) .\n" +
+                "    }\n" +
+                "    ORDER BY ASC(?distance)\n" +
+                "    LIMIT 1\n" +
+                "  }\n" +
+                "  FILTER NOT EXISTS {\n" +
+                "    lucas_r:" + id + " lucas:hasLC1 ?lc1 .\n" +
+                "    lucas_r:" + id + " lucas:hasLC1_SPEC ?lc1_sp .\n" +
+                "    ?c lictm:lucasLC1 ?lc1 .\n" +
+                "    ?c lictm:lucasLC1_spec ?lc1_sp .\n" +
+                "    ?c lictm:invekosCropTypeNumber ?l_ctype .\n" +
+                "    FILTER(?l_ctype = ?i_ctype) . \n" +
+                "  }\n" +
+                "}";
+    }
+
+    public static String getQuery3(int id) {
+        return "" +
+                "PREFIX lucas: <http://deg.iit.demokritos.gr/lucas/>\n" +
+                "PREFIX lucas_r: <http://deg.iit.demokritos.gr/lucas/resource/>\n" +
+                "PREFIX invekos: <http://deg.iit.demokritos.gr/invekos/>\n" +
+                "PREFIX lictm: <http://deg.iit.demokritos.gr/>\n" +
+                "PREFIX geof: <http://www.opengis.net/def/function/geosparql/>\n" +
+                "PREFIX geo: <http://www.opengis.net/ont/geosparql#>\n" +
+                "PREFIX opengis: <http://www.opengis.net/def/uom/OGC/1.0/>\n" +
+                "\n" +
+                "SELECT * WHERE {\n" +
+                "  lucas_r:" + id + " lucas:hasLC1 ?lc1 .\n" +
+                "  lucas_r:" + id + " lucas:hasLC1_SPEC ?lc1_sp .\n" +
+                "  ?c lictm:lucasLC1 ?lc1 .\n" +
+                "  ?c lictm:lucasLC1_spec ?lc1_sp .\n" +
+                "  {\n" +
+                "    SELECT * WHERE {\n" +
+                "      lucas_r:" + id + " geo:hasGeometry ?l_geom_id .\n" +
+                "      ?l_geom_id geo:asWKT ?l_geom .\n" +
+                "      ?inv invekos:hasCropTypeNumber ?i_ctype .\n" +
+                "      ?inv geo:hasGeometry ?i_geom_id .\n" +
+                "      ?i_geom_id geo:asWKT ?i_geom .\n" +
+                "      \n" +
+                "      BIND(geof:distance(?l_geom,?i_geom,opengis:metre) as ?distance) .\n" +
+                "      FILTER (?distance >= 0) .\n" +
+                "    }\n" +
+                "    ORDER BY ASC(?distance)\n" +
+                "    LIMIT 1\n" +
+                "  }\n" +
+                "  FILTER(?distance >= 10) .\n" +
+                "}";
+    }
+}

--- a/sparql/src/main/java/org/semagrow/connector/sparql/query/render/SPARQLQueryStringUtil.java
+++ b/sparql/src/main/java/org/semagrow/connector/sparql/query/render/SPARQLQueryStringUtil.java
@@ -155,7 +155,7 @@ public class SPARQLQueryStringUtil {
         ParsedTupleQuery query = new ParsedTupleQuery(body);
 
         String queryString = new SPARQLQueryRenderer().render(new ParsedTupleQuery(expr));
-        queryString = updateFunctionCallsSELECT(expr, queryString, computeVars(expr));
+        //queryString = updateFunctionCallsSELECT(expr, queryString, computeVars(expr));
 
         return queryString;
     }
@@ -217,7 +217,7 @@ public class SPARQLQueryStringUtil {
         }
 
         String query = new SPARQLQueryRenderer().render(new ParsedTupleQuery(expr));
-        query = updateFunctionCallsSELECT(expr, query, freeVars);
+        //query = updateFunctionCallsSELECT(expr, query, freeVars);
         freeVars.addAll(additionalBindingNames(expr));
         String where = query.substring(query.indexOf('{'));
         StringBuilder sb = new StringBuilder();
@@ -263,7 +263,7 @@ public class SPARQLQueryStringUtil {
             throws Exception
     {
         String query = new SPARQLQueryRenderer().render(new ParsedTupleQuery(expr));
-        query = updateFunctionCallsBIND(expr, query); // not tested
+        //query = updateFunctionCallsBIND(expr, query); // not tested
         relevantBindingNames.addAll(additionalBindingNames(expr)); // not tested
         String where = query.substring(query.indexOf('{'));
         StringBuilder sb = new StringBuilder();

--- a/sparql/src/main/java/org/semagrow/connector/sparql/query/render/SPARQLTupleExprRenderer.java
+++ b/sparql/src/main/java/org/semagrow/connector/sparql/query/render/SPARQLTupleExprRenderer.java
@@ -3,17 +3,7 @@ package org.semagrow.connector.sparql.query.render;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.rdf4j.query.algebra.Difference;
-import org.eclipse.rdf4j.query.algebra.Filter;
-import org.eclipse.rdf4j.query.algebra.Intersection;
-import org.eclipse.rdf4j.query.algebra.Join;
-import org.eclipse.rdf4j.query.algebra.LeftJoin;
-import org.eclipse.rdf4j.query.algebra.StatementPattern;
-import org.eclipse.rdf4j.query.algebra.TupleExpr;
-import org.eclipse.rdf4j.query.algebra.Union;
-import org.eclipse.rdf4j.query.algebra.ValueConstant;
-import org.eclipse.rdf4j.query.algebra.ValueExpr;
-import org.eclipse.rdf4j.query.algebra.Var;
+import org.eclipse.rdf4j.query.algebra.*;
 import org.eclipse.rdf4j.queryrender.BaseTupleExprRenderer;
 
 /**
@@ -303,5 +293,20 @@ public class SPARQLTupleExprRenderer extends BaseTupleExprRenderer {
                 + renderValueExpr(thePattern.getPredicateVar()) + " " + ""
                 + renderValueExpr(thePattern.getObjectVar()) + ".\n";
 
+    }
+
+
+    @Override
+    public void meet(Extension theExtension) throws Exception {
+        super.meet(theExtension);
+
+        ctxOpen(theExtension);
+
+        for (ExtensionElem elem : theExtension.getElements()) {
+            String render =  "bind(" + renderValueExpr(elem.getExpr()) + " as ?" + elem.getName() + ").";
+            mJoinBuffer.append(indent()).append(render).append("\n");
+        }
+
+        ctxClose(theExtension);
     }
 }


### PR DESCRIPTION
Updates:

1. The planner now handles queries that make use of the FILTER NOT EXISTS construct. Fixes #59 (cf. 6095bee)
2. The LIMIT operator now appears in its correct place in query plans with inner subqueries. Fixes #58 (cf. df4cefb)
3. The planner now pushes the extension (BIND clause in SPARQL) whenever possible. Closes #57 (cf. eac839d)
4. Added a heuristic in the cardinality estimator for triple patterns of the form <uri1> <uri2> ?var. Closes #49 (cf. e491332)
5. During some tests, the selectivity estimator returned an `Infinity` value, which cannot be handled by `BigDecimal`. Fixed this by substituting `Infinity` with maximum value for `Double`. (cf. a213395)