### PR TITLE
Fixes source selection of patterns with preficate variables in prefix source selector (Issue #69)

### DIFF
--- a/core/src/main/java/org/semagrow/selector/PrefixBase.java
+++ b/core/src/main/java/org/semagrow/selector/PrefixBase.java
@@ -80,6 +80,24 @@ public class PrefixBase {
                 return result;
             }
         }
+        else {
+            Variable prefix = SparqlBuilder.var("prefix");
+            Variable d = SparqlBuilder.var("d");
+
+            TriplePattern t1 = d.has(RDF.TYPE, VOID.DATASET);
+            TriplePattern t2 = d.has(VOID.SPARQLENDPOINT, endpoint);
+            TriplePattern t3 = d.has(SEVOD.SUBJECTREGEXPATTERN, prefix);
+
+            GraphPattern body = GraphPatterns.and(t1,t2,t3);
+
+            SelectQuery selectQuery = Queries.SELECT().select(prefix).where(body);
+
+            Collection<String> result = runQuery(selectQuery.getQueryString());
+
+            if (!result.isEmpty()) {
+                return result;
+            }
+        }
         return Collections.singletonList("ΑΝΥ");
     }
 
@@ -109,12 +127,30 @@ public class PrefixBase {
                 return result;
             }
         }
+        else {
+            Variable prefix = SparqlBuilder.var("prefix");
+            Variable d = SparqlBuilder.var("d");
+
+            TriplePattern t1 = d.has(RDF.TYPE, VOID.DATASET);
+            TriplePattern t2 = d.has(VOID.SPARQLENDPOINT, endpoint);
+            TriplePattern t3 = d.has(SEVOD.OBJECTREGEXPATTERN, prefix);
+
+            GraphPattern body = GraphPatterns.and(t1,t2,t3);
+
+            SelectQuery selectQuery = Queries.SELECT().select(prefix).where(body);
+
+            Collection<String> result = runQuery(selectQuery.getQueryString());
+
+            if (!result.isEmpty()) {
+                return result;
+            }
+        }
         return Collections.singletonList("ΑΝΥ");
     }
 
     private Collection<String> runQuery(String qStr){
         RepositoryConnection conn = null;
-        List<String> result = new ArrayList<>();
+        Set<String> result = new HashSet<>();
         try {
             conn = metadata.getConnection();
             TupleQuery q = conn.prepareTupleQuery(QueryLanguage.SPARQL, qStr);
@@ -129,6 +165,6 @@ public class PrefixBase {
             if (conn != null)
                 try { conn.close(); } catch (Exception e){ }
         }
-        return Collections.emptyList();
+        return Collections.emptySet();
     }
 }

--- a/core/src/main/java/org/semagrow/selector/PrefixQueryAwareSourceSelector.java
+++ b/core/src/main/java/org/semagrow/selector/PrefixQueryAwareSourceSelector.java
@@ -17,7 +17,7 @@ import java.util.*;
 public class PrefixQueryAwareSourceSelector extends SourceSelectorWrapper implements QueryAwareSourceSelector {
 
     private PrefixBase prefixBase = new PrefixBase();
-    private Map<StatementPattern,Collection<SourceMetadata>> selectorMap = new HashMap<>();
+    private Map<StatementPattern,Collection<SourceMetadata>> selectorMap;
     private boolean processed = false;
 
     public PrefixQueryAwareSourceSelector(SourceSelector selector) {
@@ -33,6 +33,7 @@ public class PrefixQueryAwareSourceSelector extends SourceSelectorWrapper implem
         if (getWrappedSelector() instanceof QueryAwareSourceSelector) {
             ((QueryAwareSourceSelector) getWrappedSelector()).processTupleExpr(expr);
         }
+        selectorMap = new HashMap<>();
         Collection<List<StatementPattern>> groups = GroupedPatternCollector.process(expr);
         for (List<StatementPattern> group: groups) {
             processBPG(group);

--- a/http-endpoint/src/main/java/org/semagrow/http/controllers/AbstractQueryController.java
+++ b/http-endpoint/src/main/java/org/semagrow/http/controllers/AbstractQueryController.java
@@ -98,6 +98,9 @@ public abstract class AbstractQueryController extends WebContentGenerator implem
                 LogUtils.initKobeReport();
                 LogUtils.appendKobeReport(kobeQueryDesc);
             }
+            else {
+                LogUtils.initKobeReport();
+            }
 
             Repository repository = getRepository(request);
             RepositoryConnection repositoryCon = getRepositoryConnection(request);


### PR DESCRIPTION
Add additional queries for patterns with predicate variables issued by the prefix source selector in metadata. Fixes #69.